### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete string escaping or encoding

### DIFF
--- a/libs/nest-graph-inspector/src/nest-graph-inspector.service.ts
+++ b/libs/nest-graph-inspector/src/nest-graph-inspector.service.ts
@@ -535,7 +535,7 @@ export class NestGraphInspectorService implements OnModuleInit {
   }
 
   private escapeMermaidLabel(value: string): string {
-    return value.replace(/"/g, '\\"');
+    return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
   }
 
   private collectReachableModules(root: any, visited: Set<string>): any[] {


### PR DESCRIPTION
Potential fix for [https://github.com/albasyir/nest-graph-inspector/security/code-scanning/1](https://github.com/albasyir/nest-graph-inspector/security/code-scanning/1)

Generally, when escaping characters for a string-like context, you must escape the escape character (`\`) itself before escaping other characters like `"`. For a simple, custom routine, this means using a global regular expression to replace all backslashes with `\\`, then all double quotes with `\"`.

In this file, the best fix is to update `escapeMermaidLabel` so that it (1) escapes all backslashes, and then (2) escapes all double quotes. This keeps functionality the same for simple inputs (strings with only quotes) but correctly handles inputs containing backslashes. We do not need any new imports or helpers; two chained `replace` calls with appropriate regexes are sufficient.

Concretely, in `libs/nest-graph-inspector/src/nest-graph-inspector.service.ts`, change the body of `escapeMermaidLabel` (around line 537–539) from a single `.replace(/"/g, '\\"')` to `.replace(/\\/g, '\\\\').replace(/"/g, '\\"')`. No other code needs to change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
