### PR TITLE
feat: add direct run provider flow

### DIFF
--- a/library/libs/nest-graph-inspector/src/adapters/direct-run-output.adapter.spec.ts
+++ b/library/libs/nest-graph-inspector/src/adapters/direct-run-output.adapter.spec.ts
@@ -55,7 +55,7 @@ describe(DirectRunOutputAdapter.name, () => {
     });
   });
 
-  it('rejects methods that require arguments', async () => {
+  it('responds to browser preflight requests for direct run', async () => {
     const port = await availablePort();
     const httpServeAdapter = moduleRef.get(HttpServeAdapter);
 
@@ -66,7 +66,77 @@ describe(DirectRunOutputAdapter.name, () => {
       },
       [
         adapter.createRoute('/direct-run', () => ({
-          ping: (_value: string) => 'pong',
+          ping: () => 'pong',
+        })),
+      ],
+    );
+    await httpServeAdapter.serve();
+
+    const response = await request(`http://127.0.0.1:${port}/direct-run`, {
+      method: 'OPTIONS',
+      headers: {
+        origin: 'https://viewer.example',
+        'access-control-request-method': 'POST',
+        'access-control-request-headers': 'content-type',
+      },
+    });
+
+    expect(response.statusCode).toBe(204);
+    expect(response.body).toBe('');
+    expect(response.headers['access-control-allow-origin']).toBe('*');
+    expect(response.headers['access-control-allow-methods']).toContain('POST');
+    expect(response.headers['access-control-allow-headers']).toBe('*');
+  });
+
+  it('accepts JSON content types with charset parameters', async () => {
+    const port = await availablePort();
+    const httpServeAdapter = moduleRef.get(HttpServeAdapter);
+
+    httpServeAdapter.register(
+      {
+        host: '127.0.0.1',
+        port,
+      },
+      [
+        adapter.createRoute('/direct-run', () => ({
+          ping: () => 'pong',
+        })),
+      ],
+    );
+    await httpServeAdapter.serve();
+
+    const response = await post(
+      `http://127.0.0.1:${port}/direct-run`,
+      {
+        module: 'AppModule',
+        provider: 'PingProvider',
+        method: 'ping',
+      },
+      {
+        'content-type': 'application/json; charset=utf-8',
+      },
+    );
+
+    expect(response.statusCode).toBe(200);
+    expect(JSON.parse(response.body)).toEqual({
+      ok: true,
+      method: 'ping',
+      result: 'pong',
+    });
+  });
+
+  it('passes JSON args to provider methods', async () => {
+    const port = await availablePort();
+    const httpServeAdapter = moduleRef.get(HttpServeAdapter);
+
+    httpServeAdapter.register(
+      {
+        host: '127.0.0.1',
+        port,
+      },
+      [
+        adapter.createRoute('/direct-run', () => ({
+          ping: (value: { message: string }) => `pong:${value.message}`,
         })),
       ],
     );
@@ -76,34 +146,85 @@ describe(DirectRunOutputAdapter.name, () => {
       module: 'AppModule',
       provider: 'PingProvider',
       method: 'ping',
+      args: {
+        message: 'hello',
+      },
     });
 
-    expect(response.statusCode).toBe(400);
+    expect(response.statusCode).toBe(200);
     expect(JSON.parse(response.body)).toEqual({
-      ok: false,
-      error: 'Method ping requires arguments and cannot be direct-run.',
+      ok: true,
+      method: 'ping',
+      result: 'pong:hello',
+    });
+  });
+
+  it('passes JSON arrays to multi-argument provider methods', async () => {
+    const port = await availablePort();
+    const httpServeAdapter = moduleRef.get(HttpServeAdapter);
+
+    httpServeAdapter.register(
+      {
+        host: '127.0.0.1',
+        port,
+      },
+      [
+        adapter.createRoute('/direct-run', () => ({
+          add: (left: number, right: number) => left + right,
+        })),
+      ],
+    );
+    await httpServeAdapter.serve();
+
+    const response = await post(`http://127.0.0.1:${port}/direct-run`, {
+      module: 'AppModule',
+      provider: 'MathProvider',
+      method: 'add',
+      args: [2, 3],
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(JSON.parse(response.body)).toEqual({
+      ok: true,
+      method: 'add',
+      result: 5,
     });
   });
 });
 
 type HttpResponse = {
   statusCode?: number;
+  headers: http.IncomingHttpHeaders;
   body: string;
 };
 
-function post(url: string, payload: unknown): Promise<HttpResponse> {
+function post(
+  url: string,
+  payload: unknown,
+  headers: http.OutgoingHttpHeaders = {},
+): Promise<HttpResponse> {
+  const body = JSON.stringify(payload);
+
+  return request(url, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'content-length': Buffer.byteLength(body),
+      ...headers,
+    },
+    body,
+  });
+}
+
+function request(
+  url: string,
+  options: http.RequestOptions & { body?: string } = {},
+): Promise<HttpResponse> {
   return new Promise((resolve, reject) => {
     const target = new URL(url);
-    const body = JSON.stringify(payload);
     const req = http.request(
       target,
-      {
-        method: 'POST',
-        headers: {
-          'content-type': 'application/json',
-          'content-length': Buffer.byteLength(body),
-        },
-      },
+      options,
       (res) => {
         let responseBody = '';
 
@@ -114,6 +235,7 @@ function post(url: string, payload: unknown): Promise<HttpResponse> {
         res.on('end', () => {
           resolve({
             statusCode: res.statusCode,
+            headers: res.headers,
             body: responseBody,
           });
         });
@@ -121,7 +243,9 @@ function post(url: string, payload: unknown): Promise<HttpResponse> {
     );
 
     req.on('error', reject);
-    req.write(body);
+    if (options.body) {
+      req.write(options.body);
+    }
     req.end();
   });
 }

--- a/library/libs/nest-graph-inspector/src/adapters/direct-run-output.adapter.spec.ts
+++ b/library/libs/nest-graph-inspector/src/adapters/direct-run-output.adapter.spec.ts
@@ -1,0 +1,150 @@
+import http from 'node:http';
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { DirectRunOutputAdapter } from './direct-run-output.adapter';
+import { HttpServeAdapter } from './http-serve.adapter';
+
+describe(DirectRunOutputAdapter.name, () => {
+  let moduleRef: TestingModule;
+  let adapter: DirectRunOutputAdapter;
+
+  beforeEach(async () => {
+    moduleRef = await Test.createTestingModule({
+      providers: [HttpServeAdapter, DirectRunOutputAdapter],
+    }).compile();
+
+    adapter = moduleRef.get(DirectRunOutputAdapter);
+  });
+
+  afterEach(() => moduleRef.close());
+
+  it('executes zero-argument provider methods over HTTP', async () => {
+    const port = await availablePort();
+    const httpServeAdapter = moduleRef.get(HttpServeAdapter);
+
+    httpServeAdapter.register(
+      {
+        host: '127.0.0.1',
+        port,
+      },
+      [
+        adapter.createRoute('/direct-run', (moduleName, providerName) => {
+          if (moduleName === 'AppModule' && providerName === 'PingProvider') {
+            return {
+              ping: () => 'pong',
+            };
+          }
+
+          return undefined;
+        }),
+      ],
+    );
+    await httpServeAdapter.serve();
+
+    const response = await post(`http://127.0.0.1:${port}/direct-run`, {
+      module: 'AppModule',
+      provider: 'PingProvider',
+      method: 'ping',
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(JSON.parse(response.body)).toEqual({
+      ok: true,
+      method: 'ping',
+      result: 'pong',
+    });
+  });
+
+  it('rejects methods that require arguments', async () => {
+    const port = await availablePort();
+    const httpServeAdapter = moduleRef.get(HttpServeAdapter);
+
+    httpServeAdapter.register(
+      {
+        host: '127.0.0.1',
+        port,
+      },
+      [
+        adapter.createRoute('/direct-run', () => ({
+          ping: (_value: string) => 'pong',
+        })),
+      ],
+    );
+    await httpServeAdapter.serve();
+
+    const response = await post(`http://127.0.0.1:${port}/direct-run`, {
+      module: 'AppModule',
+      provider: 'PingProvider',
+      method: 'ping',
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(JSON.parse(response.body)).toEqual({
+      ok: false,
+      error: 'Method ping requires arguments and cannot be direct-run.',
+    });
+  });
+});
+
+type HttpResponse = {
+  statusCode?: number;
+  body: string;
+};
+
+function post(url: string, payload: unknown): Promise<HttpResponse> {
+  return new Promise((resolve, reject) => {
+    const target = new URL(url);
+    const body = JSON.stringify(payload);
+    const req = http.request(
+      target,
+      {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'content-length': Buffer.byteLength(body),
+        },
+      },
+      (res) => {
+        let responseBody = '';
+
+        res.setEncoding('utf8');
+        res.on('data', (chunk) => {
+          responseBody += chunk;
+        });
+        res.on('end', () => {
+          resolve({
+            statusCode: res.statusCode,
+            body: responseBody,
+          });
+        });
+      },
+    );
+
+    req.on('error', reject);
+    req.write(body);
+    req.end();
+  });
+}
+
+function availablePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = http.createServer();
+
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        reject(new Error('Failed to allocate port'));
+        return;
+      }
+      const { port } = address;
+      server.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve(port);
+      });
+    });
+  });
+}

--- a/library/libs/nest-graph-inspector/src/adapters/direct-run-output.adapter.ts
+++ b/library/libs/nest-graph-inspector/src/adapters/direct-run-output.adapter.ts
@@ -1,0 +1,108 @@
+import { Injectable } from '@nestjs/common';
+import type { HttpServeResponse } from './http-serve.adapter';
+import { HttpServeAdapter } from './http-serve.adapter';
+import type { DirectRunResult } from '../types/direct-run.type';
+
+@Injectable()
+export class DirectRunOutputAdapter {
+  constructor(
+    private readonly httpServeAdapter: HttpServeAdapter,
+  ) {}
+
+  createRoute(path: string, instanceLookup: (moduleName: string, providerName: string) => unknown) {
+    return this.httpServeAdapter.post(path, async ({ request }) => {
+      const body = await this.readJsonBody(request);
+      const moduleName = typeof body.module === 'string' ? body.module : '';
+      const providerName = typeof body.provider === 'string' ? body.provider : '';
+      const methodName = typeof body.method === 'string' ? body.method : '';
+
+      if (!moduleName || !providerName || !methodName) {
+        return this.badRequest('module, provider, and method are required.');
+      }
+
+      const instance = instanceLookup(moduleName, providerName) as Record<string, unknown> | undefined;
+      if (!instance) {
+        return this.notFound(`Provider ${moduleName}:${providerName} is unavailable.`);
+      }
+
+      const method = instance[methodName];
+      if (typeof method !== 'function') {
+        return this.badRequest(`Method ${methodName} is unavailable for direct run.`);
+      }
+
+      if (method.length > 0) {
+        return this.badRequest(`Method ${methodName} requires arguments and cannot be direct-run.`);
+      }
+
+      try {
+        const result = await method.call(instance);
+        const payload: DirectRunResult = {
+          ok: true,
+          method: methodName,
+          result,
+        };
+
+        return {
+          statusCode: 200,
+          body: payload,
+        } satisfies HttpServeResponse;
+      } catch (error) {
+        const payload: DirectRunResult = {
+          ok: false,
+          method: methodName,
+          error: error instanceof Error ? error.message : 'Direct run failed.',
+        };
+
+        return {
+          statusCode: 500,
+          body: payload,
+        } satisfies HttpServeResponse;
+      }
+    }, {
+      responseHeaders: {
+        'content-type': 'application/json; charset=utf-8',
+      },
+      requestHeaders: {
+        'content-type': 'application/json',
+      },
+    });
+  }
+
+  private async readJsonBody(request: NodeJS.ReadableStream): Promise<Record<string, unknown>> {
+    let body = '';
+
+    for await (const chunk of request) {
+      body += typeof chunk === 'string' ? chunk : chunk.toString('utf8');
+    }
+
+    if (!body.trim()) {
+      return {};
+    }
+
+    try {
+      return JSON.parse(body) as Record<string, unknown>;
+    } catch {
+      return {};
+    }
+  }
+
+  private badRequest(message: string): HttpServeResponse {
+    return {
+      statusCode: 400,
+      body: {
+        ok: false,
+        error: message,
+      } satisfies DirectRunResult,
+    };
+  }
+
+  private notFound(message: string): HttpServeResponse {
+    return {
+      statusCode: 404,
+      body: {
+        ok: false,
+        error: message,
+      } satisfies DirectRunResult,
+    };
+  }
+}

--- a/library/libs/nest-graph-inspector/src/adapters/direct-run-output.adapter.ts
+++ b/library/libs/nest-graph-inspector/src/adapters/direct-run-output.adapter.ts
@@ -3,6 +3,10 @@ import type { HttpServeResponse } from './http-serve.adapter';
 import { HttpServeAdapter } from './http-serve.adapter';
 import type { DirectRunResult } from '../types/direct-run.type';
 
+type DirectRunArgsResult =
+  | { ok: true; args: unknown[] }
+  | { ok: false; response: HttpServeResponse };
+
 @Injectable()
 export class DirectRunOutputAdapter {
   constructor(
@@ -30,12 +34,13 @@ export class DirectRunOutputAdapter {
         return this.badRequest(`Method ${methodName} is unavailable for direct run.`);
       }
 
-      if (method.length > 0) {
-        return this.badRequest(`Method ${methodName} requires arguments and cannot be direct-run.`);
+      const argsResult = this.resolveArgs(body, methodName, method.length);
+      if (!argsResult.ok) {
+        return argsResult.response;
       }
 
       try {
-        const result = await method.call(instance);
+        const result = await method.call(instance, ...argsResult.args);
         const payload: DirectRunResult = {
           ok: true,
           method: methodName,
@@ -62,9 +67,6 @@ export class DirectRunOutputAdapter {
       responseHeaders: {
         'content-type': 'application/json; charset=utf-8',
       },
-      requestHeaders: {
-        'content-type': 'application/json',
-      },
     });
   }
 
@@ -84,6 +86,45 @@ export class DirectRunOutputAdapter {
     } catch {
       return {};
     }
+  }
+
+  private resolveArgs(
+    body: Record<string, unknown>,
+    methodName: string,
+    parameterCount: number,
+  ): DirectRunArgsResult {
+    if (!Object.prototype.hasOwnProperty.call(body, 'args')) {
+      if (parameterCount > 0) {
+        return {
+          ok: false,
+          response: this.badRequest(
+            `Method ${methodName} requires arguments. Send args as JSON in the request body.`,
+          ),
+        };
+      }
+
+      return { ok: true, args: [] };
+    }
+
+    const input = body.args;
+    if (parameterCount > 1 && !Array.isArray(input)) {
+      return {
+        ok: false,
+        response: this.badRequest(
+          `Method ${methodName} expects ${parameterCount} arguments. Send args as a JSON array.`,
+        ),
+      };
+    }
+
+    return {
+      ok: true,
+      args:
+        parameterCount === 1
+          ? [input]
+          : Array.isArray(input)
+            ? input
+            : [input],
+    };
   }
 
   private badRequest(message: string): HttpServeResponse {

--- a/library/libs/nest-graph-inspector/src/adapters/http-serve.adapter.ts
+++ b/library/libs/nest-graph-inspector/src/adapters/http-serve.adapter.ts
@@ -170,6 +170,11 @@ export class HttpServeAdapter implements OnModuleDestroy {
     const route = this.route(originUrl, routes, req);
 
     if (!route) {
+      if (this.isCorsPreflightRequest(req)) {
+        this.sendCorsPreflight(res);
+        return;
+      }
+
       this.sendText(res, 404, 'Not Found');
       return;
     }
@@ -393,7 +398,26 @@ export class HttpServeAdapter implements OnModuleDestroy {
 
   private setCorsHeaders(res: http.ServerResponse) {
     res.setHeader('Access-Control-Allow-Origin', '*');
+    res.setHeader(
+      'Access-Control-Allow-Methods',
+      'GET,POST,PUT,PATCH,DELETE,OPTIONS',
+    );
     res.setHeader('Access-Control-Allow-Headers', '*');
+  }
+
+  private sendCorsPreflight(res: http.ServerResponse) {
+    res.writeHead(204, {
+      'content-length': 0,
+    });
+    res.end();
+  }
+
+  private isCorsPreflightRequest(req: http.IncomingMessage): boolean {
+    return (
+      req.method === 'OPTIONS' &&
+      typeof req.headers.origin === 'string' &&
+      typeof req.headers['access-control-request-method'] === 'string'
+    );
   }
 
   private resolveDynamicPort(state: HttpServerState) {

--- a/library/libs/nest-graph-inspector/src/adapters/viewer-output.adapter.spec.ts
+++ b/library/libs/nest-graph-inspector/src/adapters/viewer-output.adapter.spec.ts
@@ -5,6 +5,7 @@ import { HttpOutputAdapter } from './http-output.adapter';
 import { HttpServeAdapter } from './http-serve.adapter';
 import { ProxyAdapter } from './proxy.adapter';
 import { ViewerOutputAdapter } from './viewer-output.adapter';
+import { DirectRunOutputAdapter } from './direct-run-output.adapter';
 
 describe(ViewerOutputAdapter.name, () => {
   let moduleRef: TestingModule;
@@ -31,6 +32,7 @@ describe(ViewerOutputAdapter.name, () => {
       providers: [
         ViewerOutputAdapter,
         HttpServeAdapter,
+        DirectRunOutputAdapter,
         {
           provide: HttpOutputAdapter,
           useValue: httpOutputAdapter,
@@ -146,7 +148,7 @@ describe(ViewerOutputAdapter.name, () => {
 
     expect(proxyAdapter.serve).toHaveBeenCalledWith(
       expect.objectContaining({
-        from: 'http://localhost:53371',
+        from: 'http://0.0.0.0:53371',
         to: 'http://localhost:11435',
       }),
       expect.objectContaining({
@@ -176,6 +178,36 @@ describe(ViewerOutputAdapter.name, () => {
         httpAdapter: httpServeAdapter,
         pathPrefix: '/ollama',
       }),
+    );
+  });
+
+  it('registers the direct-run route when configured', async () => {
+    const registerSpy = jest.spyOn(httpServeAdapter, 'register');
+
+    await adapter.execute({} as never, {
+      type: 'viewer',
+      path: 'graph',
+      ollama: {
+        origin: 'http://localhost:11434',
+        path: '/ollama',
+      },
+      directRun: {
+        path: '/direct-run',
+        instanceLookup: () => ({ ping: () => 'pong' }),
+      },
+    } as never);
+
+    expect(registerSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        host: undefined,
+        port: undefined,
+      }),
+      [
+        expect.objectContaining({
+          path: '/direct-run',
+          type: 'POST',
+        }),
+      ],
     );
   });
 });

--- a/library/libs/nest-graph-inspector/src/adapters/viewer-output.adapter.ts
+++ b/library/libs/nest-graph-inspector/src/adapters/viewer-output.adapter.ts
@@ -6,8 +6,15 @@ import type { ProxyCorsOptions } from '../ports/proxy.gateway';
 import { HttpOutputAdapter } from './http-output.adapter';
 import { ProxyAdapter } from './proxy.adapter';
 import { HttpServeAdapter } from './http-serve.adapter';
+import { DirectRunOutputAdapter } from './direct-run-output.adapter';
 
 type ViewerOutputConfig = Extract<NestGraphInspectorOutput, { type: 'viewer' }>;
+type ViewerOutputInternalConfig = ViewerOutputConfig & {
+  directRun?: {
+    path: string;
+    instanceLookup: (moduleName: string, providerName: string) => unknown;
+  };
+};
 
 @Injectable()
 export class ViewerOutputAdapter implements OutputAdapter<ViewerOutputConfig> {
@@ -19,12 +26,14 @@ export class ViewerOutputAdapter implements OutputAdapter<ViewerOutputConfig> {
     private readonly httpOutputAdapter: HttpOutputAdapter,
     private readonly proxyAdapter: ProxyAdapter,
     private readonly httpServeAdapter: HttpServeAdapter,
+    private readonly directRunOutputAdapter: DirectRunOutputAdapter,
   ) {}
 
   async execute(
     graphOutput: GraphOutput,
     config: ViewerOutputConfig,
   ): Promise<{ message: string }> {
+    const internalConfig = config as ViewerOutputInternalConfig;
     const path = this.httpOutputAdapter.normalizePath(
       config.path ?? '/__graph-inspector',
     );
@@ -49,6 +58,20 @@ export class ViewerOutputAdapter implements OutputAdapter<ViewerOutputConfig> {
         pathPrefix: ollama.path,
       },
     );
+
+    if (internalConfig.directRun?.path) {
+      this.httpServeAdapter.register(
+        {
+          origin: this.httpOrigin(config),
+          host: config.host,
+          port: config.port,
+        },
+        [this.directRunOutputAdapter.createRoute(
+          internalConfig.directRun.path,
+          (moduleName, providerName) => internalConfig.directRun?.instanceLookup(moduleName, providerName),
+        )],
+      );
+    }
 
     try {
       await this.httpServeAdapter.serve();

--- a/library/libs/nest-graph-inspector/src/nest-graph-inspector.module.spec.ts
+++ b/library/libs/nest-graph-inspector/src/nest-graph-inspector.module.spec.ts
@@ -21,6 +21,9 @@ describe(NestGraphInspectorModule.name, () => {
             origin: 'http://localhost:11434',
             path: '/ollama',
           },
+          directRun: {
+            path: '/direct-run',
+          },
         },
       ],
       ignoreProvider: ['ModuleRef', 'ApplicationConfig'],

--- a/library/libs/nest-graph-inspector/src/nest-graph-inspector.module.ts
+++ b/library/libs/nest-graph-inspector/src/nest-graph-inspector.module.ts
@@ -11,6 +11,7 @@ import { ViewerOutputAdapter } from './adapters/viewer-output.adapter';
 import { NestGraphInspectorModuleOptions } from './nest-graph-inspector.type';
 import { ProxyAdapter } from './adapters/proxy.adapter';
 import { HttpServeAdapter } from './adapters/http-serve.adapter';
+import { DirectRunOutputAdapter } from './adapters/direct-run-output.adapter';
 
 export const defaultOptions: NestGraphInspectorModuleOptions = {
   outputs: [
@@ -20,6 +21,9 @@ export const defaultOptions: NestGraphInspectorModuleOptions = {
       ollama: {
         origin: 'http://localhost:11434',
         path: '/ollama',
+      },
+      directRun: {
+        path: '/direct-run',
       },
     },
   ],
@@ -47,6 +51,7 @@ export const defaultOptions: NestGraphInspectorModuleOptions = {
     HttpServeAdapter,
     HttpOutputAdapter,
     ProxyAdapter,
+    DirectRunOutputAdapter,
     ViewerOutputAdapter,
   ],
 })

--- a/library/libs/nest-graph-inspector/src/nest-graph-inspector.setup.spec.ts
+++ b/library/libs/nest-graph-inspector/src/nest-graph-inspector.setup.spec.ts
@@ -393,13 +393,10 @@ describe(NestGraphInspectorSetup.name, () => {
         dependencies: [],
         directRun: {
           methods: [
-            { name: 'ping', parameterCount: 0 },
+            { name: 'ping', parameterTypes: '[]' },
             {
               name: 'withArgs',
-              parameterCount: 1,
-              parameterNames: ['value'],
-              parameterTypes: ['string'],
-              parameterSchemas: [{ type: 'string' }],
+              parameterTypes: '[value: string]',
             },
           ],
         },

--- a/library/libs/nest-graph-inspector/src/nest-graph-inspector.setup.spec.ts
+++ b/library/libs/nest-graph-inspector/src/nest-graph-inspector.setup.spec.ts
@@ -366,7 +366,7 @@ describe(NestGraphInspectorSetup.name, () => {
     ]);
   });
 
-  it('should include direct-run metadata for zero-argument providers', () => {
+  it('should include direct-run metadata for provider methods', () => {
     class RunnableProvider {
       ping() {
         return 'pong';
@@ -392,7 +392,16 @@ describe(NestGraphInspectorSetup.name, () => {
         name: RunnableProvider.name,
         dependencies: [],
         directRun: {
-          methods: [{ name: 'ping' }],
+          methods: [
+            { name: 'ping', parameterCount: 0 },
+            {
+              name: 'withArgs',
+              parameterCount: 1,
+              parameterNames: ['value'],
+              parameterTypes: ['string'],
+              parameterSchemas: [{ type: 'string' }],
+            },
+          ],
         },
       },
     ]);

--- a/library/libs/nest-graph-inspector/src/nest-graph-inspector.setup.spec.ts
+++ b/library/libs/nest-graph-inspector/src/nest-graph-inspector.setup.spec.ts
@@ -280,7 +280,7 @@ describe(NestGraphInspectorSetup.name, () => {
 
     expect(viewerOutputAdapter.execute).toHaveBeenCalledWith(
       expect.any(Object),
-      {
+      expect.objectContaining({
         type: 'viewer',
         host: '127.0.0.1',
         port: 3998,
@@ -288,7 +288,11 @@ describe(NestGraphInspectorSetup.name, () => {
           origin: 'http://localhost:11434',
           path: '/ollama',
         },
-      },
+        directRun: expect.objectContaining({
+          path: '/direct-run',
+          instanceLookup: expect.any(Function),
+        }),
+      }),
     );
   });
 
@@ -309,7 +313,7 @@ describe(NestGraphInspectorSetup.name, () => {
 
     expect(viewerOutputAdapter.execute).toHaveBeenCalledWith(
       expect.any(Object),
-      {
+      expect.objectContaining({
         type: 'viewer',
         host: '127.0.0.1',
         port: 3998,
@@ -317,7 +321,11 @@ describe(NestGraphInspectorSetup.name, () => {
           origin: 'http://localhost:11435',
           path: '/llm',
         },
-      },
+        directRun: expect.objectContaining({
+          path: '/direct-run',
+          instanceLookup: expect.any(Function),
+        }),
+      }),
     );
   });
 
@@ -354,6 +362,38 @@ describe(NestGraphInspectorSetup.name, () => {
         name: DocumentedProvider.name,
         jsdoc: 'Provides documented app behavior.',
         dependencies: [],
+      },
+    ]);
+  });
+
+  it('should include direct-run metadata for zero-argument providers', () => {
+    class RunnableProvider {
+      ping() {
+        return 'pong';
+      }
+
+      withArgs(value: string) {
+        return value;
+      }
+    }
+
+    appModuleRef.providers.set(RunnableProvider.name, {
+      metatype: RunnableProvider,
+      instance: new RunnableProvider(),
+      token: RunnableProvider,
+    });
+
+    const graphOutput = (
+      service as unknown as SetupWithPrivateMethods
+    ).enrichModuleMap(service.buildModuleMap(TestRootModule));
+
+    expect(graphOutput.modules[TestRootModule.name].providers).toEqual([
+      {
+        name: RunnableProvider.name,
+        dependencies: [],
+        directRun: {
+          methods: [{ name: 'ping' }],
+        },
       },
     ]);
   });

--- a/library/libs/nest-graph-inspector/src/nest-graph-inspector.setup.ts
+++ b/library/libs/nest-graph-inspector/src/nest-graph-inspector.setup.ts
@@ -21,7 +21,11 @@ import { ModuleController } from './types/module-controller.type';
 import { ModuleProvider } from './types/module-provider.type';
 import { Modules } from './types/module.type';
 import { ModuleMap } from './types/module-map.type';
-import type { DirectRunProviderMeta } from './types/direct-run.type';
+import type {
+  DirectRunJsonSchema,
+  DirectRunProviderMeta,
+  DirectRunProviderMethod,
+} from './types/direct-run.type';
 import type {
   GraphOutput,
   GraphOutputCycle,
@@ -38,7 +42,7 @@ import { FileOutputAdapter } from './adapters/file-output.adapter';
 import { JsonOutputAdapter } from './adapters/json-output.adapter';
 import { ViewerOutputAdapter } from './adapters/viewer-output.adapter';
 import { OutputAdapter } from './ports/output.adapter';
-import { Project } from 'ts-morph';
+import { Node, Project, SyntaxKind, Type as TsMorphType } from 'ts-morph';
 import type { NestGraphInspectorViewerDirectRunOptions } from './nest-graph-inspector.type';
 
 type DependencyNodeKind = 'provider' | 'controller';
@@ -49,6 +53,11 @@ type DependencyNode = {
   name: string;
 };
 type NextCycleId = () => number;
+type DirectRunMethodParameterMetadata = {
+  parameterNames?: string[];
+  parameterTypes?: string[];
+  parameterSchemas?: DirectRunJsonSchema[];
+};
 type ModuleTree = {
   name: string;
   jsdoc?: string;
@@ -864,13 +873,13 @@ export class NestGraphInspectorSetup implements OnModuleInit {
       return undefined;
     }
 
-    const methods = this.getDirectRunMethodNames(instance);
+    const methods = this.getDirectRunMethods(instance);
     if (!methods.length) {
       return undefined;
     }
 
     return {
-      methods: methods.map(name => ({ name })),
+      methods,
     };
   }
 
@@ -902,7 +911,7 @@ export class NestGraphInspectorSetup implements OnModuleInit {
     return providerWrapper?.instance;
   }
 
-  private getDirectRunMethodNames(instance: unknown): string[] {
+  private getDirectRunMethods(instance: unknown): DirectRunProviderMethod[] {
     if (!instance || (typeof instance !== 'object' && typeof instance !== 'function')) {
       return [];
     }
@@ -912,15 +921,301 @@ export class NestGraphInspectorSetup implements OnModuleInit {
       return [];
     }
 
-    const methodNames = Object.getOwnPropertyNames(prototype)
+    const methods = Object.getOwnPropertyNames(prototype)
       .filter(name => name !== 'constructor')
-      .filter((name) => {
+      .map((name) => {
         const candidate = prototype[name];
-        return typeof candidate === 'function' && candidate.length === 0;
-      })
-      .sort((left, right) => left.localeCompare(right));
+        if (typeof candidate !== 'function') {
+          return null;
+        }
 
-    return [...new Set(methodNames)];
+        const method = candidate as (...args: unknown[]) => unknown;
+        const parameterCount = method.length;
+        const parameterMetadata = this.getDirectRunMethodParameterMetadata({
+          instance,
+          method,
+          methodName: name,
+          parameterCount,
+        });
+
+        return {
+          name,
+          parameterCount,
+          ...(parameterMetadata.parameterNames
+            ? { parameterNames: parameterMetadata.parameterNames }
+            : {}),
+          ...(parameterMetadata.parameterTypes
+            ? { parameterTypes: parameterMetadata.parameterTypes }
+            : {}),
+          ...(parameterMetadata.parameterSchemas
+            ? { parameterSchemas: parameterMetadata.parameterSchemas }
+            : {}),
+        };
+      })
+      .filter((method): method is DirectRunProviderMethod => method !== null)
+      .sort((left, right) => left.name.localeCompare(right.name));
+
+    return [...new Map(methods.map(method => [method.name, method])).values()];
+  }
+
+  private getDirectRunMethodParameterMetadata(param: {
+    instance: object | ((...args: unknown[]) => unknown);
+    method: (...args: unknown[]) => unknown;
+    methodName: string;
+    parameterCount: number;
+  }): DirectRunMethodParameterMetadata {
+    const { instance, method, methodName, parameterCount } = param;
+    if (parameterCount === 0) {
+      return {};
+    }
+
+    const className =
+      typeof instance === 'function'
+        ? instance.name
+        : instance.constructor?.name;
+    const sourceMetadata = className
+      ? this.extractMethodParameterMetadataFromProject(className, methodName)
+      : undefined;
+    if (
+      sourceMetadata?.parameterNames?.length === parameterCount
+      && sourceMetadata.parameterTypes?.length === parameterCount
+      && sourceMetadata.parameterSchemas?.length === parameterCount
+    ) {
+      return sourceMetadata;
+    }
+
+    const runtimeNames = this.extractMethodParameterNamesFromFunctionSource(
+      methodName,
+      method,
+    );
+    return runtimeNames && runtimeNames.length === parameterCount
+      ? { parameterNames: runtimeNames }
+      : {};
+  }
+
+  private extractMethodParameterMetadataFromProject(
+    className: string,
+    methodName: string,
+  ): DirectRunMethodParameterMetadata | undefined {
+    const targetClass = this.tsMorphProject
+      .getSourceFiles()
+      .flatMap(sourceFile =>
+        sourceFile.getDescendantsOfKind(SyntaxKind.ClassDeclaration),
+      )
+      .find(classDeclaration => classDeclaration.getName() === className);
+
+    const method = targetClass?.getInstanceMethod(methodName);
+    if (!method) {
+      return undefined;
+    }
+
+    const parameters = method.getParameters();
+    return {
+      parameterNames: parameters.map(parameter => parameter.getName()),
+      parameterTypes: parameters.map(parameter =>
+        parameter.getType().getText(parameter),
+      ),
+      parameterSchemas: parameters.map(parameter =>
+        this.typeToJsonSchema(parameter.getType(), parameter),
+      ),
+    };
+  }
+
+  private extractMethodParameterNamesFromFunctionSource(
+    methodName: string,
+    method: (...args: unknown[]) => unknown,
+  ): string[] | undefined {
+    const methodSource = method.toString().trim();
+    const project = new Project({ useInMemoryFileSystem: true });
+
+    try {
+      const sourceFile = project.createSourceFile(
+        'direct-run-method.ts',
+        `class DirectRunMethodSource { ${methodSource} }`,
+      );
+
+      const names = sourceFile
+        .getClassOrThrow('DirectRunMethodSource')
+        .getInstanceMethod(methodName)
+        ?.getParameters()
+        .map(parameter => parameter.getName());
+      if (names) {
+        return names;
+      }
+    } catch {
+      // Runtime function strings are best-effort metadata only.
+    }
+
+    try {
+      const sourceFile = project.createSourceFile(
+        'direct-run-function.ts',
+        `const directRunMethod = ${methodSource};`,
+      );
+      const initializer = sourceFile
+        .getVariableDeclarationOrThrow('directRunMethod')
+        .getInitializer();
+      const callable =
+        initializer?.asKind(SyntaxKind.FunctionExpression) ??
+        initializer?.asKind(SyntaxKind.ArrowFunction);
+
+      return callable?.getParameters().map(parameter => parameter.getName());
+    } catch {
+      return undefined;
+    }
+  }
+
+  private typeToJsonSchema(
+    type: TsMorphType,
+    enclosingNode: Node,
+    seenTypeTexts = new Set<string>(),
+  ): DirectRunJsonSchema {
+    if (
+      type.isAny()
+      || type.isUnknown()
+      || type.isNever()
+      || type.isUndefined()
+      || type.isVoid()
+    ) {
+      return {};
+    }
+
+    if (type.isString()) {
+      return { type: 'string' };
+    }
+
+    if (type.isNumber()) {
+      return { type: 'number' };
+    }
+
+    if (type.isBoolean()) {
+      return { type: 'boolean' };
+    }
+
+    if (type.isNull()) {
+      return { type: 'null' };
+    }
+
+    if (type.isStringLiteral() || type.isNumberLiteral()) {
+      return { enum: [type.getLiteralValue()] };
+    }
+
+    if (type.isBooleanLiteral()) {
+      return { enum: [type.getText(enclosingNode) === 'true'] };
+    }
+
+    if (type.isUnion()) {
+      const unionTypes = type
+        .getUnionTypes()
+        .filter(unionType => !unionType.isUndefined());
+      const literalValues = unionTypes
+        .filter(unionType =>
+          unionType.isStringLiteral()
+          || unionType.isNumberLiteral()
+          || unionType.isBooleanLiteral(),
+        )
+        .map((unionType) => {
+          if (unionType.isBooleanLiteral()) {
+            return unionType.getText(enclosingNode) === 'true';
+          }
+
+          return unionType.getLiteralValue();
+        });
+
+      if (literalValues.length === unionTypes.length && literalValues.length > 0) {
+        return { enum: literalValues };
+      }
+
+      const schemas = unionTypes
+        .map(unionType =>
+          this.typeToJsonSchema(unionType, enclosingNode, new Set(seenTypeTexts)),
+        )
+        .filter(schema => Object.keys(schema).length > 0);
+
+      if (schemas.length === 0) {
+        return {};
+      }
+
+      return schemas.length === 1 ? schemas[0] : { anyOf: schemas };
+    }
+
+    if (type.isTuple()) {
+      const tupleElements = type.getTupleElements();
+      return {
+        type: 'array',
+        minItems: tupleElements.length,
+        maxItems: tupleElements.length,
+        items: tupleElements.map(tupleType =>
+          this.typeToJsonSchema(
+            tupleType,
+            enclosingNode,
+            new Set(seenTypeTexts),
+          ),
+        ),
+      };
+    }
+
+    if (type.isArray() || type.isReadonlyArray()) {
+      return {
+        type: 'array',
+        items: this.typeToJsonSchema(
+          type.getArrayElementType() ?? type,
+          enclosingNode,
+          new Set(seenTypeTexts),
+        ),
+      };
+    }
+
+    if (!type.isObject() || type.getCallSignatures().length > 0) {
+      return {};
+    }
+
+    const typeText = type.getText(enclosingNode);
+    if (seenTypeTexts.has(typeText)) {
+      return {};
+    }
+
+    seenTypeTexts.add(typeText);
+
+    const properties: Record<string, DirectRunJsonSchema> = {};
+    const required: string[] = [];
+    for (const property of type.getProperties()) {
+      const propertyName = property.getName();
+      const propertyNode =
+        property.getValueDeclaration() ?? property.getDeclarations()[0];
+      const propertyType = property.getTypeAtLocation(
+        propertyNode ?? enclosingNode,
+      );
+
+      properties[propertyName] = this.typeToJsonSchema(
+        propertyType,
+        propertyNode ?? enclosingNode,
+        new Set(seenTypeTexts),
+      );
+
+      if (
+        !property.isOptional()
+        && !this.typeAllowsUndefined(propertyType)
+      ) {
+        required.push(propertyName);
+      }
+    }
+
+    if (Object.keys(properties).length === 0) {
+      return {};
+    }
+
+    return {
+      type: 'object',
+      additionalProperties: true,
+      properties,
+      ...(required.length ? { required } : {}),
+    };
+  }
+
+  private typeAllowsUndefined(type: TsMorphType): boolean {
+    return type.isUndefined()
+      || (type.isUnion()
+        && type.getUnionTypes().some(unionType => unionType.isUndefined()));
   }
 
   private findGraphCycles(

--- a/library/libs/nest-graph-inspector/src/nest-graph-inspector.setup.ts
+++ b/library/libs/nest-graph-inspector/src/nest-graph-inspector.setup.ts
@@ -22,7 +22,6 @@ import { ModuleProvider } from './types/module-provider.type';
 import { Modules } from './types/module.type';
 import { ModuleMap } from './types/module-map.type';
 import type {
-  DirectRunJsonSchema,
   DirectRunProviderMeta,
   DirectRunProviderMethod,
 } from './types/direct-run.type';
@@ -53,11 +52,6 @@ type DependencyNode = {
   name: string;
 };
 type NextCycleId = () => number;
-type DirectRunMethodParameterMetadata = {
-  parameterNames?: string[];
-  parameterTypes?: string[];
-  parameterSchemas?: DirectRunJsonSchema[];
-};
 type ModuleTree = {
   name: string;
   jsdoc?: string;
@@ -930,26 +924,15 @@ export class NestGraphInspectorSetup implements OnModuleInit {
         }
 
         const method = candidate as (...args: unknown[]) => unknown;
-        const parameterCount = method.length;
-        const parameterMetadata = this.getDirectRunMethodParameterMetadata({
+        const parameterTypes = this.getDirectRunMethodParameterTypes({
           instance,
           method,
           methodName: name,
-          parameterCount,
         });
 
         return {
           name,
-          parameterCount,
-          ...(parameterMetadata.parameterNames
-            ? { parameterNames: parameterMetadata.parameterNames }
-            : {}),
-          ...(parameterMetadata.parameterTypes
-            ? { parameterTypes: parameterMetadata.parameterTypes }
-            : {}),
-          ...(parameterMetadata.parameterSchemas
-            ? { parameterSchemas: parameterMetadata.parameterSchemas }
-            : {}),
+          parameterTypes,
         };
       })
       .filter((method): method is DirectRunProviderMethod => method !== null)
@@ -958,45 +941,38 @@ export class NestGraphInspectorSetup implements OnModuleInit {
     return [...new Map(methods.map(method => [method.name, method])).values()];
   }
 
-  private getDirectRunMethodParameterMetadata(param: {
+  private getDirectRunMethodParameterTypes(param: {
     instance: object | ((...args: unknown[]) => unknown);
     method: (...args: unknown[]) => unknown;
     methodName: string;
-    parameterCount: number;
-  }): DirectRunMethodParameterMetadata {
-    const { instance, method, methodName, parameterCount } = param;
-    if (parameterCount === 0) {
-      return {};
-    }
-
+  }): string {
+    const { instance, method, methodName } = param;
     const className =
       typeof instance === 'function'
         ? instance.name
         : instance.constructor?.name;
-    const sourceMetadata = className
-      ? this.extractMethodParameterMetadataFromProject(className, methodName)
+    const sourceTypes = className
+      ? this.extractMethodParameterTypesFromProject(className, methodName)
       : undefined;
-    if (
-      sourceMetadata?.parameterNames?.length === parameterCount
-      && sourceMetadata.parameterTypes?.length === parameterCount
-      && sourceMetadata.parameterSchemas?.length === parameterCount
-    ) {
-      return sourceMetadata;
+    if (sourceTypes) {
+      return sourceTypes;
     }
 
     const runtimeNames = this.extractMethodParameterNamesFromFunctionSource(
       methodName,
       method,
     );
-    return runtimeNames && runtimeNames.length === parameterCount
-      ? { parameterNames: runtimeNames }
-      : {};
+    if (!runtimeNames?.length) {
+      return '[]';
+    }
+
+    return `[${runtimeNames.map(name => `${name}: unknown`).join(', ')}]`;
   }
 
-  private extractMethodParameterMetadataFromProject(
+  private extractMethodParameterTypesFromProject(
     className: string,
     methodName: string,
-  ): DirectRunMethodParameterMetadata | undefined {
+  ): string | undefined {
     const targetClass = this.tsMorphProject
       .getSourceFiles()
       .flatMap(sourceFile =>
@@ -1010,15 +986,11 @@ export class NestGraphInspectorSetup implements OnModuleInit {
     }
 
     const parameters = method.getParameters();
-    return {
-      parameterNames: parameters.map(parameter => parameter.getName()),
-      parameterTypes: parameters.map(parameter =>
-        parameter.getType().getText(parameter),
-      ),
-      parameterSchemas: parameters.map(parameter =>
-        this.typeToJsonSchema(parameter.getType(), parameter),
-      ),
-    };
+    return `[${parameters
+      .map(parameter =>
+        `${parameter.getName()}: ${this.typeToTypeScriptCode(parameter.getType(), parameter)}`,
+      )
+      .join(', ')}]`;
   }
 
   private extractMethodParameterNamesFromFunctionSource(
@@ -1064,152 +1036,137 @@ export class NestGraphInspectorSetup implements OnModuleInit {
     }
   }
 
-  private typeToJsonSchema(
+  private typeToTypeScriptCode(
     type: TsMorphType,
     enclosingNode: Node,
     seenTypeTexts = new Set<string>(),
-  ): DirectRunJsonSchema {
+  ): string {
     if (
       type.isAny()
       || type.isUnknown()
-      || type.isNever()
-      || type.isUndefined()
-      || type.isVoid()
     ) {
-      return {};
+      return 'unknown';
+    }
+
+    if (type.isNever()) {
+      return 'never';
+    }
+
+    if (type.isUndefined()) {
+      return 'undefined';
+    }
+
+    if (type.isVoid()) {
+      return 'void';
     }
 
     if (type.isString()) {
-      return { type: 'string' };
+      return 'string';
     }
 
     if (type.isNumber()) {
-      return { type: 'number' };
+      return 'number';
     }
 
     if (type.isBoolean()) {
-      return { type: 'boolean' };
+      return 'boolean';
     }
 
     if (type.isNull()) {
-      return { type: 'null' };
+      return 'null';
     }
 
-    if (type.isStringLiteral() || type.isNumberLiteral()) {
-      return { enum: [type.getLiteralValue()] };
+    if (type.isStringLiteral()) {
+      return JSON.stringify(type.getLiteralValue());
+    }
+
+    if (type.isNumberLiteral()) {
+      return String(type.getLiteralValue());
     }
 
     if (type.isBooleanLiteral()) {
-      return { enum: [type.getText(enclosingNode) === 'true'] };
+      return type.getText(enclosingNode);
     }
 
     if (type.isUnion()) {
-      const unionTypes = type
+      return type
         .getUnionTypes()
-        .filter(unionType => !unionType.isUndefined());
-      const literalValues = unionTypes
-        .filter(unionType =>
-          unionType.isStringLiteral()
-          || unionType.isNumberLiteral()
-          || unionType.isBooleanLiteral(),
-        )
-        .map((unionType) => {
-          if (unionType.isBooleanLiteral()) {
-            return unionType.getText(enclosingNode) === 'true';
-          }
-
-          return unionType.getLiteralValue();
-        });
-
-      if (literalValues.length === unionTypes.length && literalValues.length > 0) {
-        return { enum: literalValues };
-      }
-
-      const schemas = unionTypes
         .map(unionType =>
-          this.typeToJsonSchema(unionType, enclosingNode, new Set(seenTypeTexts)),
+          this.typeToTypeScriptCode(
+            unionType,
+            enclosingNode,
+            new Set(seenTypeTexts),
+          ),
         )
-        .filter(schema => Object.keys(schema).length > 0);
-
-      if (schemas.length === 0) {
-        return {};
-      }
-
-      return schemas.length === 1 ? schemas[0] : { anyOf: schemas };
+        .join(' | ');
     }
 
     if (type.isTuple()) {
-      const tupleElements = type.getTupleElements();
-      return {
-        type: 'array',
-        minItems: tupleElements.length,
-        maxItems: tupleElements.length,
-        items: tupleElements.map(tupleType =>
-          this.typeToJsonSchema(
+      return `[${type
+        .getTupleElements()
+        .map(tupleType =>
+          this.typeToTypeScriptCode(
             tupleType,
             enclosingNode,
             new Set(seenTypeTexts),
           ),
-        ),
-      };
+        )
+        .join(', ')}]`;
     }
 
     if (type.isArray() || type.isReadonlyArray()) {
-      return {
-        type: 'array',
-        items: this.typeToJsonSchema(
-          type.getArrayElementType() ?? type,
-          enclosingNode,
-          new Set(seenTypeTexts),
-        ),
-      };
+      const itemType = this.typeToTypeScriptCode(
+        type.getArrayElementType() ?? type,
+        enclosingNode,
+        new Set(seenTypeTexts),
+      );
+
+      return `${this.wrapArrayItemType(itemType)}[]`;
     }
 
     if (!type.isObject() || type.getCallSignatures().length > 0) {
-      return {};
+      return type.getText(enclosingNode);
     }
 
     const typeText = type.getText(enclosingNode);
     if (seenTypeTexts.has(typeText)) {
-      return {};
+      return typeText;
     }
 
     seenTypeTexts.add(typeText);
 
-    const properties: Record<string, DirectRunJsonSchema> = {};
-    const required: string[] = [];
-    for (const property of type.getProperties()) {
-      const propertyName = property.getName();
-      const propertyNode =
-        property.getValueDeclaration() ?? property.getDeclarations()[0];
-      const propertyType = property.getTypeAtLocation(
-        propertyNode ?? enclosingNode,
-      );
-
-      properties[propertyName] = this.typeToJsonSchema(
-        propertyType,
-        propertyNode ?? enclosingNode,
-        new Set(seenTypeTexts),
-      );
-
-      if (
-        !property.isOptional()
-        && !this.typeAllowsUndefined(propertyType)
-      ) {
-        required.push(propertyName);
-      }
+    const properties = type.getProperties();
+    if (properties.length === 0) {
+      return typeText;
     }
 
-    if (Object.keys(properties).length === 0) {
-      return {};
-    }
+    return `{ ${properties
+      .map((property) => {
+        const propertyNode =
+          property.getValueDeclaration() ?? property.getDeclarations()[0];
+        const propertyType = property.getTypeAtLocation(
+          propertyNode ?? enclosingNode,
+        );
+        const optional = property.isOptional()
+          || this.typeAllowsUndefined(propertyType);
 
-    return {
-      type: 'object',
-      additionalProperties: true,
-      properties,
-      ...(required.length ? { required } : {}),
-    };
+        return `${this.propertyNameToTypeScriptCode(property.getName())}${optional ? '?' : ''}: ${this.typeToTypeScriptCode(
+          propertyType,
+          propertyNode ?? enclosingNode,
+          new Set(seenTypeTexts),
+        )}`;
+      })
+      .join('; ')} }`;
+  }
+
+  private wrapArrayItemType(typeText: string): string {
+    return typeText.includes(' | ') || typeText.includes('&')
+      ? `(${typeText})`
+      : typeText;
+  }
+
+  private propertyNameToTypeScriptCode(name: string): string {
+    return /^[A-Za-z_$][\w$]*$/.test(name) ? name : JSON.stringify(name);
   }
 
   private typeAllowsUndefined(type: TsMorphType): boolean {

--- a/library/libs/nest-graph-inspector/src/nest-graph-inspector.setup.ts
+++ b/library/libs/nest-graph-inspector/src/nest-graph-inspector.setup.ts
@@ -21,6 +21,7 @@ import { ModuleController } from './types/module-controller.type';
 import { ModuleProvider } from './types/module-provider.type';
 import { Modules } from './types/module.type';
 import { ModuleMap } from './types/module-map.type';
+import type { DirectRunProviderMeta } from './types/direct-run.type';
 import type {
   GraphOutput,
   GraphOutputCycle,
@@ -30,6 +31,7 @@ import type {
   GraphOutputModule,
   GraphOutputProviderCycle,
   GraphOutputProviderCyclePathItem,
+  GraphOutputProvider,
 } from './types/graph-output.type';
 import { HttpOutputAdapter } from './adapters/http-output.adapter';
 import { FileOutputAdapter } from './adapters/file-output.adapter';
@@ -37,6 +39,7 @@ import { JsonOutputAdapter } from './adapters/json-output.adapter';
 import { ViewerOutputAdapter } from './adapters/viewer-output.adapter';
 import { OutputAdapter } from './ports/output.adapter';
 import { Project } from 'ts-morph';
+import type { NestGraphInspectorViewerDirectRunOptions } from './nest-graph-inspector.type';
 
 type DependencyNodeKind = 'provider' | 'controller';
 type DependencyNode = {
@@ -219,6 +222,26 @@ export class NestGraphInspectorSetup implements OnModuleInit {
         ...defaultViewerOutput.ollama,
         ...output.ollama,
       },
+      directRun: this.mergeViewerDirectRunOptions(
+        defaultViewerOutput.directRun,
+        output.directRun,
+      ),
+    };
+  }
+
+  private mergeViewerDirectRunOptions(
+    defaultOptions?: NestGraphInspectorViewerDirectRunOptions,
+    outputOptions?: NestGraphInspectorViewerDirectRunOptions,
+  ) {
+    const path = outputOptions?.path ?? defaultOptions?.path;
+    if (!path) {
+      return undefined;
+    }
+
+    return {
+      path,
+      instanceLookup: (moduleName: string, providerName: string) =>
+        this.findDirectRunProviderInstance(moduleName, providerName),
     };
   }
 
@@ -814,6 +837,7 @@ export class NestGraphInspectorSetup implements OnModuleInit {
           dependencies: provider.dependencies.map((dep) =>
             this.enrichDependency(dep, moduleName),
           ),
+          directRun: this.resolveDirectRunProviderMeta(provider.name, moduleName),
         })),
         controllers: moduleData.controllers.map((controller) => ({
           ...controller,
@@ -829,6 +853,74 @@ export class NestGraphInspectorSetup implements OnModuleInit {
       modules: enrichedModules,
       cycles: this.findGraphCycles(enrichedModules),
     };
+  }
+
+  private resolveDirectRunProviderMeta(
+    providerName: string,
+    moduleName: string,
+  ): DirectRunProviderMeta | undefined {
+    const instance = this.findDirectRunProviderInstance(moduleName, providerName);
+    if (!instance) {
+      return undefined;
+    }
+
+    const methods = this.getDirectRunMethodNames(instance);
+    if (!methods.length) {
+      return undefined;
+    }
+
+    return {
+      methods: methods.map(name => ({ name })),
+    };
+  }
+
+  private findDirectRunProviderInstance(
+    moduleName: string,
+    providerName: string,
+  ): unknown {
+    const moduleRef = [...this.modulesContainer.values()].find(
+      candidate => this.moduleName(candidate) === moduleName,
+    );
+    if (!moduleRef) {
+      return undefined;
+    }
+
+    const providerWrapper = [...moduleRef.providers.values()].find((wrapper) => {
+      const instance =
+        wrapper.instance &&
+        (typeof wrapper.instance === 'object' || typeof wrapper.instance === 'function')
+          ? (wrapper.instance as { constructor?: { name?: string } })
+          : null;
+      const resolvedName =
+        wrapper.metatype?.name ||
+        instance?.constructor?.name ||
+        this.tokenName(wrapper.token);
+
+      return resolvedName === providerName;
+    });
+
+    return providerWrapper?.instance;
+  }
+
+  private getDirectRunMethodNames(instance: unknown): string[] {
+    if (!instance || (typeof instance !== 'object' && typeof instance !== 'function')) {
+      return [];
+    }
+
+    const prototype = Object.getPrototypeOf(instance) as Record<string, unknown> | null;
+    if (!prototype || prototype === Object.prototype) {
+      return [];
+    }
+
+    const methodNames = Object.getOwnPropertyNames(prototype)
+      .filter(name => name !== 'constructor')
+      .filter((name) => {
+        const candidate = prototype[name];
+        return typeof candidate === 'function' && candidate.length === 0;
+      })
+      .sort((left, right) => left.localeCompare(right));
+
+    return [...new Set(methodNames)];
   }
 
   private findGraphCycles(

--- a/library/libs/nest-graph-inspector/src/nest-graph-inspector.type.ts
+++ b/library/libs/nest-graph-inspector/src/nest-graph-inspector.type.ts
@@ -5,6 +5,10 @@ export type NestGraphInspectorOllamaProxyOptions = {
   path?: string;
 };
 
+export type NestGraphInspectorViewerDirectRunOptions = {
+  path?: string;
+};
+
 export type NestGraphInspectorOutput =
   | {
       type: 'viewer';
@@ -13,6 +17,7 @@ export type NestGraphInspectorOutput =
       port?: number;
       path?: string;
       ollama?: NestGraphInspectorOllamaProxyOptions;
+      directRun?: NestGraphInspectorViewerDirectRunOptions;
     }
   | { type: 'markdown'; path: string }
   | { type: 'json'; path: string }
@@ -38,10 +43,12 @@ export interface NestGraphInspectorModuleOptions {
    * - `type: 'http'` serves the module map from a native HTTP server on the
    *   given host, port, and route path, plus raw JSON and markdown at
    *   `/output.json` and `/output.md` under that path
-   * - `type: 'viewer'` serves the graph for the visualizer and proxies Ollama
+   * - `type: 'viewer'` serves the graph for the visualizer, proxies Ollama
    *   requests from the configured same-origin path to the configured Ollama
-   *   origin. If origin is provided, it prints a direct viewer URL. Otherwise,
-   *   it prints the viewer URL and the endpoint path to enter in the viewer.
+   *   origin, and exposes direct-run provider execution on the configured
+   *   same-origin path. If origin is provided, it prints a direct viewer URL.
+   *   Otherwise, it prints the viewer URL and the endpoint path to enter in
+   *   the viewer.
    */
   outputs?: NestGraphInspectorOutput[];
 

--- a/library/libs/nest-graph-inspector/src/types/direct-run.type.ts
+++ b/library/libs/nest-graph-inspector/src/types/direct-run.type.ts
@@ -1,5 +1,11 @@
+export type DirectRunJsonSchema = Record<string, unknown>;
+
 export type DirectRunProviderMethod = {
   name: string;
+  parameterCount: number;
+  parameterNames?: string[];
+  parameterTypes?: string[];
+  parameterSchemas?: DirectRunJsonSchema[];
 };
 
 export type DirectRunProviderMeta = {

--- a/library/libs/nest-graph-inspector/src/types/direct-run.type.ts
+++ b/library/libs/nest-graph-inspector/src/types/direct-run.type.ts
@@ -1,0 +1,14 @@
+export type DirectRunProviderMethod = {
+  name: string;
+};
+
+export type DirectRunProviderMeta = {
+  methods: DirectRunProviderMethod[];
+};
+
+export type DirectRunResult = {
+  ok: boolean;
+  method?: string;
+  result?: unknown;
+  error?: string;
+};

--- a/library/libs/nest-graph-inspector/src/types/direct-run.type.ts
+++ b/library/libs/nest-graph-inspector/src/types/direct-run.type.ts
@@ -1,11 +1,6 @@
-export type DirectRunJsonSchema = Record<string, unknown>;
-
 export type DirectRunProviderMethod = {
   name: string;
-  parameterCount: number;
-  parameterNames?: string[];
-  parameterTypes?: string[];
-  parameterSchemas?: DirectRunJsonSchema[];
+  parameterTypes: string;
 };
 
 export type DirectRunProviderMeta = {

--- a/library/libs/nest-graph-inspector/src/types/graph-output.schema.ts
+++ b/library/libs/nest-graph-inspector/src/types/graph-output.schema.ts
@@ -65,6 +65,32 @@ export const GRAPH_OUTPUT_JSON_SCHEMA = {
             $ref: '#/$defs/dependencyRef',
           },
         },
+        directRun: {
+          $ref: '#/$defs/directRunProviderMeta',
+        },
+      },
+    },
+    directRunProviderMethod: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['name'],
+      properties: {
+        name: {
+          type: 'string',
+        },
+      },
+    },
+    directRunProviderMeta: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['methods'],
+      properties: {
+        methods: {
+          type: 'array',
+          items: {
+            $ref: '#/$defs/directRunProviderMethod',
+          },
+        },
       },
     },
     controller: {

--- a/library/libs/nest-graph-inspector/src/types/graph-output.schema.ts
+++ b/library/libs/nest-graph-inspector/src/types/graph-output.schema.ts
@@ -73,10 +73,33 @@ export const GRAPH_OUTPUT_JSON_SCHEMA = {
     directRunProviderMethod: {
       type: 'object',
       additionalProperties: false,
-      required: ['name'],
+      required: ['name', 'parameterCount'],
       properties: {
         name: {
           type: 'string',
+        },
+        parameterCount: {
+          type: 'number',
+          minimum: 0,
+        },
+        parameterNames: {
+          type: 'array',
+          items: {
+            type: 'string',
+          },
+        },
+        parameterTypes: {
+          type: 'array',
+          items: {
+            type: 'string',
+          },
+        },
+        parameterSchemas: {
+          type: 'array',
+          items: {
+            type: 'object',
+            additionalProperties: true,
+          },
         },
       },
     },

--- a/library/libs/nest-graph-inspector/src/types/graph-output.schema.ts
+++ b/library/libs/nest-graph-inspector/src/types/graph-output.schema.ts
@@ -73,33 +73,13 @@ export const GRAPH_OUTPUT_JSON_SCHEMA = {
     directRunProviderMethod: {
       type: 'object',
       additionalProperties: false,
-      required: ['name', 'parameterCount'],
+      required: ['name', 'parameterTypes'],
       properties: {
         name: {
           type: 'string',
         },
-        parameterCount: {
-          type: 'number',
-          minimum: 0,
-        },
-        parameterNames: {
-          type: 'array',
-          items: {
-            type: 'string',
-          },
-        },
         parameterTypes: {
-          type: 'array',
-          items: {
-            type: 'string',
-          },
-        },
-        parameterSchemas: {
-          type: 'array',
-          items: {
-            type: 'object',
-            additionalProperties: true,
-          },
+          type: 'string',
         },
       },
     },

--- a/library/libs/nest-graph-inspector/src/types/graph-output.type.ts
+++ b/library/libs/nest-graph-inspector/src/types/graph-output.type.ts
@@ -3,10 +3,13 @@ export type GraphOutputDependencyRef = {
   token: string;
 };
 
+import type { DirectRunProviderMeta } from './direct-run.type';
+
 export type GraphOutputProvider = {
   name: string;
   jsdoc?: string;
   dependencies: GraphOutputDependencyRef[];
+  directRun?: DirectRunProviderMeta;
 };
 
 export type GraphOutputController = {

--- a/library/src/user/user.controller.ts
+++ b/library/src/user/user.controller.ts
@@ -12,7 +12,7 @@ export class UserController {
   @Post()
   createUser(@Body() body: { name: string; email: string }) {
     this.userSchedule.reward();
-    return this.userService.createUser(body.name, body.email);
+    return this.userService.createUser(body);
   }
 
   @Get()

--- a/library/src/user/user.service.ts
+++ b/library/src/user/user.service.ts
@@ -9,7 +9,7 @@ export class UserService {
 
   constructor(private readonly userRepository: UserRepository) {}
 
-  createUser(name: string, email: string): User {
+  createUser({ name, email }: { name: string; email: string }): User {
     return this.userRepository.create(name, email);
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,6 +101,9 @@ importers:
 
   site:
     dependencies:
+      '@guolao/vue-monaco-editor':
+        specifier: ^1.6.0
+        version: 1.6.0(monaco-editor@0.55.1)(vue@3.5.38(typescript@6.0.3))
       '@iconify-json/lucide':
         specifier: ^1.2.113
         version: 1.2.113
@@ -170,6 +173,9 @@ importers:
       minimark:
         specifier: ^0.2.0
         version: 0.2.0
+      monaco-editor:
+        specifier: ^0.55.1
+        version: 0.55.1
       nuxt:
         specifier: ^4.4.8
         version: 4.4.8(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@22.19.17)(@vue/compiler-sfc@3.5.38)(better-sqlite3@12.11.1)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.11.1))(eslint@10.5.0(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.38(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.62.0))(rollup@4.62.0)(srvx@0.11.15)(terser@5.46.1)(typescript@6.0.3)(vite@7.3.5(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.9.0))(vue-tsc@3.3.5(typescript@6.0.3))(yaml@2.9.0)
@@ -1002,6 +1008,16 @@ packages:
   '@floating-ui/vue@1.1.11':
     resolution: {integrity: sha512-HzHKCNVxnGS35r9fCHBc3+uCnjw9IWIlCPL683cGgM9Kgj2BiAl8x1mS7vtvP6F9S/e/q4O6MApwSHj8hNLGfw==}
 
+  '@guolao/vue-monaco-editor@1.6.0':
+    resolution: {integrity: sha512-w2IiJ6eJGGeuIgCK6EKZOAfhHTTUB5aZwslzwGbZ5e89Hb4avx6++GkLTW8p84Sng/arFMjLPPxSBI56cFudyQ==}
+    peerDependencies:
+      '@vue/composition-api': ^1.7.2
+      monaco-editor: '>=0.43.0'
+      vue: ^2.6.14 || >=3.0.0
+    peerDependenciesMeta:
+      '@vue/composition-api':
+        optional: true
+
   '@hono/node-server@1.19.13':
     resolution: {integrity: sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==}
     engines: {node: '>=18.14.1'}
@@ -1550,6 +1566,9 @@ packages:
     peerDependenciesMeta:
       '@cfworker/json-schema':
         optional: true
+
+  '@monaco-editor/loader@1.7.0':
+    resolution: {integrity: sha512-gIwR1HrJrrx+vfyOhYmCZ0/JcWqG5kbfG7+d3f/C1LXk2EvzAbHSg3MQ5lO2sMlo9izoAZ04shohfKLVT6crVA==}
 
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
@@ -5268,6 +5287,9 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
+  dompurify@3.2.7:
+    resolution: {integrity: sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==}
+
   dompurify@3.3.3:
     resolution: {integrity: sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==}
 
@@ -6950,6 +6972,11 @@ packages:
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
 
+  marked@14.0.0:
+    resolution: {integrity: sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==}
+    engines: {node: '>= 18'}
+    hasBin: true
+
   marked@16.4.2:
     resolution: {integrity: sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==}
     engines: {node: '>= 20'}
@@ -7208,6 +7235,9 @@ packages:
 
   mocked-exports@0.1.1:
     resolution: {integrity: sha512-aF7yRQr/Q0O2/4pIXm6PZ5G+jAd7QS4Yu8m+WEeEHGnbo+7mE36CbLSDQiXYV8bVL3NfmdeqPJct0tUlnjVSnA==}
+
+  monaco-editor@0.55.1:
+    resolution: {integrity: sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==}
 
   motion-dom@12.40.0:
     resolution: {integrity: sha512-HxU3ZaBwNPVQUBQf1xxgq+7JrPNZvjLVxgbpEZL7RrWJnsxOf0/OM+yrHG9ogLQ31Do/r57Oz2gQWPK+6q62mg==}
@@ -8495,6 +8525,9 @@ packages:
 
   standard-as-callback@2.1.0:
     resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
+
+  state-local@1.0.7:
+    resolution: {integrity: sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==}
 
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
@@ -10333,6 +10366,13 @@ snapshots:
       - '@vue/composition-api'
       - vue
 
+  '@guolao/vue-monaco-editor@1.6.0(monaco-editor@0.55.1)(vue@3.5.38(typescript@6.0.3))':
+    dependencies:
+      '@monaco-editor/loader': 1.7.0
+      monaco-editor: 0.55.1
+      vue: 3.5.38(typescript@6.0.3)
+      vue-demi: 0.14.10(vue@3.5.38(typescript@6.0.3))
+
   '@hono/node-server@1.19.13(hono@4.12.12)':
     dependencies:
       hono: 4.12.12
@@ -10962,6 +11002,10 @@ snapshots:
       '@cfworker/json-schema': 4.1.1
     transitivePeerDependencies:
       - supports-color
+
+  '@monaco-editor/loader@1.7.0':
+    dependencies:
+      state-local: 1.0.7
 
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
@@ -14986,6 +15030,10 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
+  dompurify@3.2.7:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
+
   dompurify@3.3.3:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
@@ -17111,6 +17159,8 @@ snapshots:
 
   markdown-table@3.0.4: {}
 
+  marked@14.0.0: {}
+
   marked@16.4.2: {}
 
   marked@17.0.6: {}
@@ -17537,6 +17587,11 @@ snapshots:
       ufo: 1.6.4
 
   mocked-exports@0.1.1: {}
+
+  monaco-editor@0.55.1:
+    dependencies:
+      dompurify: 3.2.7
+      marked: 14.0.0
 
   motion-dom@12.40.0:
     dependencies:
@@ -19397,6 +19452,8 @@ snapshots:
       escape-string-regexp: 2.0.0
 
   standard-as-callback@2.1.0: {}
+
+  state-local@1.0.7: {}
 
   statuses@2.0.2: {}
 

--- a/site/app/components/GraphViewer.vue
+++ b/site/app/components/GraphViewer.vue
@@ -16,6 +16,7 @@ import { NodeResizer } from '@vue-flow/node-resizer'
 import { useDebounceFn, useResizeObserver } from '@vueuse/core'
 import type { CSSProperties } from 'vue'
 import type { Node, Edge, EdgeProps, NodeMouseEvent } from '@vue-flow/core'
+import type * as Monaco from 'monaco-editor'
 import type {
   GraphOutput,
   GraphOutputModule,
@@ -31,7 +32,8 @@ import { resolveCircularDependencyEndpoints } from '~/utils/circular-dependency-
 import {
   getDirectRunProviderState,
   parseProviderNodeId,
-  type DirectRunExecutionSnapshot
+  type DirectRunExecutionSnapshot,
+  type DirectRunProviderMethod
 } from '~/utils/direct-run-provider'
 
 function normalizeDep(dep: GraphOutputDependencyRef): {
@@ -60,6 +62,7 @@ type DirectRunActionRequest = {
   moduleName: string
   providerName: string
   methodName: string
+  args?: unknown[]
 }
 
 type DirectRunProviderContext = {
@@ -72,6 +75,20 @@ type DirectRunStatusBadge = {
   label: string
   color: 'neutral' | 'primary' | 'success' | 'error'
   variant: 'soft' | 'solid' | 'outline'
+}
+
+type DirectRunMethodTab = {
+  label: string
+  value: string
+  method: DirectRunProviderMethod
+  badge?: string
+}
+
+type DirectRunArgsJsonSchema = Monaco.json.JSONSchema
+type DirectRunEditorMarker = Monaco.editor.IMarker
+type DirectRunArgsSchemaCacheEntry = {
+  fingerprint: string
+  schema: DirectRunArgsJsonSchema
 }
 
 type ModuleItemLayout = ItemNodeData & {
@@ -1356,6 +1373,11 @@ const directRunStateByNodeId = ref<Record<string, DirectRunExecutionSnapshot>>({
 const selectedProviderNodeId = ref<string | null>(null)
 const directRunPendingMethodByNodeId = ref<Record<string, string>>({})
 const directRunErrorByNodeId = ref<Record<string, string>>({})
+const directRunArgsInputByKey = ref<Record<string, string>>({})
+const directRunArgsErrorByKey = ref<Record<string, string>>({})
+const directRunArgsInvalidByKey = ref<Record<string, boolean>>({})
+const directRunActiveTab = ref<string>('')
+const directRunArgsSchemaCache = new Map<string, DirectRunArgsSchemaCacheEntry>()
 const initialGraph = buildGraph(graphData.value, collapsedModuleNames.value, {
   showCircularDependencies: showCircularDependencies.value,
   showModuleToModuleLine: showModuleToModuleLine.value,
@@ -1473,6 +1495,24 @@ const selectedProviderDirectRunState = computed(() => {
   const context = selectedProviderContext.value
   return context ? getDirectRunProviderState(context.provider) : null
 })
+const showDirectRunDrawer = computed({
+  get: () => Boolean(selectedProviderContext.value),
+  set: (value: boolean) => {
+    if (!value) {
+      selectedProviderNodeId.value = null
+    }
+  }
+})
+const directRunMethodTabs = computed<DirectRunMethodTab[]>(() =>
+  (selectedProviderDirectRunState.value?.methods || []).map(method => ({
+    label: method.name,
+    value: method.name,
+    method,
+    badge: method.parameterCount
+      ? `${method.parameterCount} ${method.parameterCount === 1 ? 'arg' : 'args'}`
+      : undefined
+  }))
+)
 const selectedProviderSnapshot = computed(() => {
   const nodeId = selectedProviderContext.value?.nodeId
   return nodeId ? directRunStateByNodeId.value[nodeId] || null : null
@@ -1484,6 +1524,21 @@ const selectedProviderPendingMethod = computed(() => {
 const selectedProviderError = computed(() => {
   const nodeId = selectedProviderContext.value?.nodeId
   return nodeId ? directRunErrorByNodeId.value[nodeId] || '' : ''
+})
+const selectedProviderArgsErrors = computed<Record<string, string>>(() => {
+  const context = selectedProviderContext.value
+  if (!context) {
+    return {}
+  }
+
+  return Object.fromEntries(
+    (selectedProviderDirectRunState.value?.methods || []).map(method => [
+      method.name,
+      directRunArgsErrorByKey.value[
+        directRunArgsKey(context.nodeId, method.name)
+      ] || ''
+    ])
+  )
 })
 const selectedProviderLastRunLabel = computed(() => {
   const value = selectedProviderSnapshot.value?.updatedAt
@@ -1683,6 +1738,470 @@ function clearDirectRunError(nodeId: string): void {
   directRunErrorByNodeId.value = nextErrorState
 }
 
+function directRunArgsKey(nodeId: string, methodName: string): string {
+  return `${nodeId}:${methodName}`
+}
+
+function getDirectRunMethodSignature(method: DirectRunProviderMethod): string {
+  const parameterCount = method.parameterCount || 0
+  if (parameterCount === 0) {
+    return `${method.name}()`
+  }
+
+  const args = getDirectRunParameterNames(method).join(', ')
+
+  return `${method.name}(${args})`
+}
+
+function getDirectRunParameterNames(method: DirectRunProviderMethod): string[] {
+  const parameterCount = method.parameterCount || 0
+  if (
+    method.parameterNames
+    && method.parameterNames.length === parameterCount
+  ) {
+    return method.parameterNames
+  }
+
+  return Array.from(
+    { length: parameterCount },
+    (_, index) => `arg${index + 1}`
+  )
+}
+
+function getDirectRunParameterTypes(method: DirectRunProviderMethod): string[] {
+  const parameterCount = method.parameterCount || 0
+  if (
+    method.parameterTypes
+    && method.parameterTypes.length === parameterCount
+  ) {
+    return method.parameterTypes
+  }
+
+  return Array.from({ length: parameterCount }, () => 'unknown')
+}
+
+function getDirectRunParameterSchemas(method: DirectRunProviderMethod): DirectRunArgsJsonSchema[] {
+  const parameterCount = method.parameterCount || 0
+  if (
+    method.parameterSchemas
+    && method.parameterSchemas.length === parameterCount
+  ) {
+    return method.parameterSchemas as DirectRunArgsJsonSchema[]
+  }
+
+  return Array.from({ length: parameterCount }, () => ({}))
+}
+
+function getDirectRunEditorPath(methodName: string): string {
+  const context = selectedProviderContext.value
+  if (!context) {
+    return `direct-run://${methodName}.json`
+  }
+
+  return `direct-run://${context.moduleName}/${context.provider.name}/${methodName}.json`
+}
+
+function getDirectRunArgsSchema(method: DirectRunProviderMethod): DirectRunArgsJsonSchema {
+  const context = selectedProviderContext.value
+  const cacheKey = context
+    ? directRunArgsKey(context.nodeId, method.name)
+    : method.name
+  const fingerprint = JSON.stringify({
+    parameterCount: method.parameterCount || 0,
+    parameterNames: method.parameterNames || [],
+    parameterTypes: method.parameterTypes || [],
+    parameterSchemas: method.parameterSchemas || []
+  })
+  const cachedSchema = directRunArgsSchemaCache.get(cacheKey)
+  if (cachedSchema?.fingerprint === fingerprint) {
+    return cachedSchema.schema
+  }
+
+  const schema = buildDirectRunArgsSchema(method)
+  directRunArgsSchemaCache.set(cacheKey, {
+    fingerprint,
+    schema
+  })
+
+  return schema
+}
+
+function buildDirectRunArgsSchema(method: DirectRunProviderMethod): DirectRunArgsJsonSchema {
+  const parameterCount = method.parameterCount || 0
+  const parameterNames = getDirectRunParameterNames(method)
+  const parameterTypes = getDirectRunParameterTypes(method)
+  const parameterSchemas = getDirectRunParameterSchemas(method)
+
+  if (parameterCount <= 1) {
+    const parameterName = parameterNames[0] || 'argument'
+    const parameterType = parameterTypes[0] || 'unknown'
+    const parameterSchema = parameterSchemas[0] || {}
+
+    return {
+      $schema: 'http://json-schema.org/draft-07/schema#',
+      title: `${method.name}() ${parameterName}`,
+      description: `JSON value passed as ${parameterName}: ${parameterType}.`,
+      ...parameterSchema
+    }
+  }
+
+  return {
+    $schema: 'http://json-schema.org/draft-07/schema#',
+    title: `${method.name}() arguments`,
+    description: `JSON array passed as ${parameterCount} method arguments.`,
+    type: 'array',
+    minItems: parameterCount,
+    maxItems: parameterCount,
+    items: Array.from(
+      { length: parameterCount },
+      (_, index): DirectRunArgsJsonSchema => ({
+        title: parameterNames[index] || `arg${index + 1}`,
+        description: parameterTypes[index] || 'unknown',
+        ...(parameterSchemas[index] || {})
+      })
+    )
+  }
+}
+
+function getDirectRunArgsInput(methodName: string): string {
+  const nodeId = selectedProviderContext.value?.nodeId
+  return nodeId
+    ? directRunArgsInputByKey.value[directRunArgsKey(nodeId, methodName)] || ''
+    : ''
+}
+
+function setDirectRunArgsInput(methodName: string, value: unknown): void {
+  const nodeId = selectedProviderContext.value?.nodeId
+  if (!nodeId) {
+    return
+  }
+
+  const key = directRunArgsKey(nodeId, methodName)
+  directRunArgsInputByKey.value = {
+    ...directRunArgsInputByKey.value,
+    [key]: typeof value === 'string' ? value : String(value ?? '')
+  }
+
+  const { [key]: _removed, ...nextArgsErrorState } = directRunArgsErrorByKey.value
+  directRunArgsErrorByKey.value = nextArgsErrorState
+}
+
+function setDirectRunArgsValidation(
+  methodName: string,
+  markers: DirectRunEditorMarker[]
+): void {
+  const nodeId = selectedProviderContext.value?.nodeId
+  if (!nodeId) {
+    return
+  }
+
+  directRunArgsInvalidByKey.value = {
+    ...directRunArgsInvalidByKey.value,
+    [directRunArgsKey(nodeId, methodName)]: markers.some(marker =>
+      marker.severity >= 8
+    )
+  }
+}
+
+function hasDirectRunArgsValidationError(methodName: string): boolean {
+  const nodeId = selectedProviderContext.value?.nodeId
+  return nodeId
+    ? Boolean(directRunArgsInvalidByKey.value[directRunArgsKey(nodeId, methodName)])
+    : false
+}
+
+function isDirectRunActionDisabled(method: DirectRunProviderMethod): boolean {
+  if (selectedProviderPendingMethod.value) {
+    return true
+  }
+
+  if (!method.parameterCount) {
+    return false
+  }
+
+  return !parseDirectRunArgs(method, getDirectRunArgsInput(method.name)).ok
+    || hasDirectRunArgsValidationError(method.name)
+}
+
+function getDirectRunArgsError(method: DirectRunProviderMethod): string {
+  const storedError = selectedProviderArgsErrors.value[method.name]
+  if (storedError) {
+    return storedError
+  }
+
+  const input = getDirectRunArgsInput(method.name)
+  if (!input.trim()) {
+    return ''
+  }
+
+  const parsedArgs = parseDirectRunArgs(method, input)
+  return parsedArgs.ok ? '' : parsedArgs.error
+}
+
+function setDirectRunArgsError(
+  nodeId: string,
+  methodName: string,
+  error: string
+): void {
+  directRunArgsErrorByKey.value = {
+    ...directRunArgsErrorByKey.value,
+    [directRunArgsKey(nodeId, methodName)]: error
+  }
+}
+
+function clearDirectRunArgsError(nodeId: string, methodName: string): void {
+  const key = directRunArgsKey(nodeId, methodName)
+  const { [key]: _removed, ...nextArgsErrorState } = directRunArgsErrorByKey.value
+  directRunArgsErrorByKey.value = nextArgsErrorState
+}
+
+function parseDirectRunArgs(
+  method: DirectRunProviderMethod,
+  input: string
+): { ok: true, args: unknown[] | undefined } | { ok: false, error: string } {
+  const parameterCount = method.parameterCount || 0
+  if (parameterCount === 0) {
+    return { ok: true, args: undefined }
+  }
+
+  const trimmedInput = input.trim()
+  if (!trimmedInput) {
+    return {
+      ok: false,
+      error: `Enter JSON arguments for ${method.name}().`
+    }
+  }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(trimmedInput)
+  } catch {
+    return {
+      ok: false,
+      error: 'Arguments must be valid JSON.'
+    }
+  }
+
+  if (parameterCount === 1) {
+    const validationError = validateDirectRunParsedArgs(method, [parsed])
+    if (validationError) {
+      return { ok: false, error: validationError }
+    }
+
+    return { ok: true, args: [parsed] }
+  }
+
+  if (!Array.isArray(parsed)) {
+    return {
+      ok: false,
+      error: `${method.name}() expects ${parameterCount} arguments. Use a JSON array.`
+    }
+  }
+
+  const validationError = validateDirectRunParsedArgs(method, parsed)
+  if (validationError) {
+    return { ok: false, error: validationError }
+  }
+
+  return { ok: true, args: parsed }
+}
+
+function validateDirectRunParsedArgs(
+  method: DirectRunProviderMethod,
+  args: unknown[]
+): string {
+  const parameterCount = method.parameterCount || 0
+  if (args.length !== parameterCount) {
+    return `${method.name}() expects ${parameterCount} arguments.`
+  }
+
+  const parameterNames = getDirectRunParameterNames(method)
+  const parameterSchemas = getDirectRunParameterSchemas(method)
+
+  for (let index = 0; index < parameterCount; index += 1) {
+    const error = validateJsonSchemaValue(
+      args[index],
+      parameterSchemas[index] || {},
+      parameterNames[index] || `arg${index + 1}`
+    )
+    if (error) {
+      return error
+    }
+  }
+
+  return ''
+}
+
+function validateJsonSchemaValue(
+  value: unknown,
+  schema: DirectRunArgsJsonSchema,
+  label: string
+): string {
+  if (schema.enum && Array.isArray(schema.enum)) {
+    const matchesEnum = schema.enum.some(candidate =>
+      JSON.stringify(candidate) === JSON.stringify(value)
+    )
+    if (!matchesEnum) {
+      return `${label} must be one of ${schema.enum.map(String).join(', ')}.`
+    }
+  }
+
+  const unionSchemas = Array.isArray(schema.anyOf)
+    ? schema.anyOf
+    : Array.isArray(schema.oneOf)
+      ? schema.oneOf
+      : null
+  if (unionSchemas) {
+    const hasMatch = unionSchemas.some(candidate =>
+      !validateJsonSchemaValue(value, candidate as DirectRunArgsJsonSchema, label)
+    )
+    return hasMatch ? '' : `${label} does not match the expected type.`
+  }
+
+  const typeError = validateJsonSchemaType(value, schema, label)
+  if (typeError) {
+    return typeError
+  }
+
+  if (Array.isArray(value)) {
+    return validateJsonSchemaArray(value, schema, label)
+  }
+
+  if (value && typeof value === 'object') {
+    return validateJsonSchemaObject(
+      value as Record<string, unknown>,
+      schema,
+      label
+    )
+  }
+
+  return ''
+}
+
+function validateJsonSchemaType(
+  value: unknown,
+  schema: DirectRunArgsJsonSchema,
+  label: string
+): string {
+  const schemaType = schema.type
+  const allowedTypes = Array.isArray(schemaType)
+    ? schemaType
+    : typeof schemaType === 'string'
+      ? [schemaType]
+      : []
+
+  if (allowedTypes.length === 0) {
+    return ''
+  }
+
+  const isValid = allowedTypes.some((type) => {
+    if (type === 'string') {
+      return typeof value === 'string'
+    }
+    if (type === 'number') {
+      return typeof value === 'number' && Number.isFinite(value)
+    }
+    if (type === 'integer') {
+      return Number.isInteger(value)
+    }
+    if (type === 'boolean') {
+      return typeof value === 'boolean'
+    }
+    if (type === 'array') {
+      return Array.isArray(value)
+    }
+    if (type === 'object') {
+      return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+    }
+    if (type === 'null') {
+      return value === null
+    }
+    return true
+  })
+
+  return isValid ? '' : `${label} must be ${allowedTypes.join(' or ')}.`
+}
+
+function validateJsonSchemaArray(
+  value: unknown[],
+  schema: DirectRunArgsJsonSchema,
+  label: string
+): string {
+  if (typeof schema.minItems === 'number' && value.length < schema.minItems) {
+    return `${label} must contain at least ${schema.minItems} items.`
+  }
+
+  if (typeof schema.maxItems === 'number' && value.length > schema.maxItems) {
+    return `${label} must contain at most ${schema.maxItems} items.`
+  }
+
+  if (Array.isArray(schema.items)) {
+    for (let index = 0; index < schema.items.length; index += 1) {
+      const error = validateJsonSchemaValue(
+        value[index],
+        schema.items[index] as DirectRunArgsJsonSchema,
+        `${label}[${index}]`
+      )
+      if (error) {
+        return error
+      }
+    }
+    return ''
+  }
+
+  if (schema.items && typeof schema.items === 'object') {
+    for (let index = 0; index < value.length; index += 1) {
+      const error = validateJsonSchemaValue(
+        value[index],
+        schema.items as DirectRunArgsJsonSchema,
+        `${label}[${index}]`
+      )
+      if (error) {
+        return error
+      }
+    }
+  }
+
+  return ''
+}
+
+function validateJsonSchemaObject(
+  value: Record<string, unknown>,
+  schema: DirectRunArgsJsonSchema,
+  label: string
+): string {
+  const required = Array.isArray(schema.required)
+    ? schema.required.filter((key): key is string => typeof key === 'string')
+    : []
+  for (const key of required) {
+    if (!Object.prototype.hasOwnProperty.call(value, key)) {
+      return `${label}.${key} is required.`
+    }
+  }
+
+  const properties = schema.properties
+  if (!properties || typeof properties !== 'object' || Array.isArray(properties)) {
+    return ''
+  }
+
+  for (const [key, propertySchema] of Object.entries(properties)) {
+    if (!Object.prototype.hasOwnProperty.call(value, key)) {
+      continue
+    }
+
+    const error = validateJsonSchemaValue(
+      value[key],
+      propertySchema as DirectRunArgsJsonSchema,
+      `${label}.${key}`
+    )
+    if (error) {
+      return error
+    }
+  }
+
+  return ''
+}
+
 async function emitDirectRun(request: DirectRunActionRequest): Promise<void> {
   const nodeId = `provider-${request.moduleName}-${request.providerName}`
   directRunPendingMethodByNodeId.value = {
@@ -1724,18 +2243,44 @@ function applyDirectRunFailure(payload: {
   setDirectRunError(nodeId, payload.error)
 }
 
-function requestDirectRun(methodName: string): void {
+function requestDirectRun(method: DirectRunProviderMethod): void {
   const context = selectedProviderContext.value
   if (!context) {
     return
   }
 
+  const parsedArgs = parseDirectRunArgs(method, getDirectRunArgsInput(method.name))
+  if (!parsedArgs.ok) {
+    setDirectRunArgsError(context.nodeId, method.name, parsedArgs.error)
+    return
+  }
+
+  clearDirectRunArgsError(context.nodeId, method.name)
   void emitDirectRun({
     moduleName: context.moduleName,
     providerName: context.provider.name,
-    methodName
+    methodName: method.name,
+    args: parsedArgs.args
   })
 }
+
+watch(
+  () => ({
+    nodeId: selectedProviderContext.value?.nodeId || '',
+    tabs: directRunMethodTabs.value.map(tab => tab.value)
+  }),
+  ({ tabs }) => {
+    if (tabs.length === 0) {
+      directRunActiveTab.value = ''
+      return
+    }
+
+    if (!tabs.includes(directRunActiveTab.value)) {
+      directRunActiveTab.value = tabs[0] || ''
+    }
+  },
+  { immediate: true }
+)
 
 function openCircularTooltip(edgeId: string): void {
   activeCircularTooltipEdgeId.value = edgeId
@@ -2280,87 +2825,161 @@ useResizeObserver(graphViewerRef, () => {
       <MiniMap v-if="props.interactive" />
     </VueFlow>
 
-    <div
-      v-if="selectedProviderContext"
-      class="direct-run-panel nodrag nopan"
-      aria-label="Direct run provider panel"
+    <UDrawer
+      v-model:open="showDirectRunDrawer"
+      direction="right"
+      :ui="{ content: 'w-screen max-w-md' }"
     >
-      <div class="direct-run-panel__header">
-        <div class="min-w-0">
-          <p class="direct-run-panel__eyebrow">
-            Provider Action
-          </p>
-          <p class="direct-run-panel__title">
-            {{ selectedProviderContext.provider.name }}
-          </p>
-          <p class="direct-run-panel__subtitle">
-            {{ selectedProviderContext.moduleName }}
-          </p>
+      <template #header>
+        <div class="direct-run-drawer__header">
+          <div class="min-w-0">
+            <p class="direct-run-drawer__eyebrow">
+              Provider Action
+            </p>
+            <p class="direct-run-drawer__title">
+              {{ selectedProviderContext?.provider.name }}
+            </p>
+            <p class="direct-run-drawer__subtitle">
+              {{ selectedProviderContext?.moduleName }}
+            </p>
+          </div>
+
+          <div class="direct-run-drawer__header-actions">
+            <UBadge
+              v-if="selectedProviderStatusBadge"
+              :label="selectedProviderStatusBadge.label"
+              :color="selectedProviderStatusBadge.color"
+              :variant="selectedProviderStatusBadge.variant"
+            />
+            <UButton
+              icon="i-lucide-x"
+              color="neutral"
+              variant="ghost"
+              square
+              aria-label="Close direct run drawer"
+              @click="showDirectRunDrawer = false"
+            />
+          </div>
         </div>
-        <UBadge
-          v-if="selectedProviderStatusBadge"
-          :label="selectedProviderStatusBadge.label"
-          :color="selectedProviderStatusBadge.color"
-          :variant="selectedProviderStatusBadge.variant"
-        />
-      </div>
+      </template>
 
-      <p
-        v-if="selectedProviderDirectRunState && !selectedProviderDirectRunState.runnable"
-        class="direct-run-panel__message"
-      >
-        {{ selectedProviderDirectRunState.reason }}
-      </p>
+      <template #body>
+        <div class="direct-run-drawer__body">
+          <p
+            v-if="selectedProviderDirectRunState && !selectedProviderDirectRunState.runnable"
+            class="direct-run-drawer__message"
+          >
+            {{ selectedProviderDirectRunState.reason }}
+          </p>
 
-      <div
-        v-else-if="selectedProviderDirectRunState"
-        class="direct-run-panel__actions"
-      >
-        <UButton
-          v-for="method in selectedProviderDirectRunState.methods"
-          :key="method.name"
-          type="button"
-          :label="`Direct Run ${method.name}()`"
-          icon="i-lucide-play"
-          color="primary"
-          :loading="selectedProviderPendingMethod === method.name"
-          :disabled="Boolean(selectedProviderPendingMethod)"
-          @click="requestDirectRun(method.name)"
-        />
-      </div>
+          <UTabs
+            v-else-if="directRunMethodTabs.length"
+            v-model="directRunActiveTab"
+            :items="directRunMethodTabs"
+            color="primary"
+            variant="pill"
+            :ui="{
+              root: 'gap-4',
+              list: 'w-full overflow-x-auto',
+              trigger: 'shrink-0',
+              content: 'outline-none'
+            }"
+          >
+            <template #content="{ item }">
+              <div class="direct-run-drawer__method">
+                <div class="direct-run-drawer__method-header">
+                  <div class="min-w-0">
+                    <p class="direct-run-drawer__method-name">
+                      {{ getDirectRunMethodSignature(item.method) }}
+                    </p>
+                    <p
+                      v-if="item.method.parameterCount"
+                      class="direct-run-drawer__method-subtitle"
+                    >
+                      JSON arguments
+                    </p>
+                  </div>
+                  <UBadge
+                    v-if="item.method.parameterCount"
+                    :label="`${item.method.parameterCount} ${item.method.parameterCount === 1 ? 'arg' : 'args'}`"
+                    color="neutral"
+                    variant="soft"
+                  />
+                </div>
 
-      <p
-        v-if="selectedProviderPendingMethod"
-        class="direct-run-panel__message"
-      >
-        Running {{ selectedProviderPendingMethod }}()…
-      </p>
+                <ClientOnly v-if="item.method.parameterCount">
+                  <JsonMonacoEditor
+                    :model-value="getDirectRunArgsInput(item.method.name)"
+                    :path="getDirectRunEditorPath(item.method.name)"
+                    :schema="getDirectRunArgsSchema(item.method)"
+                    :readonly="Boolean(selectedProviderPendingMethod)"
+                    height="240px"
+                    @update:model-value="value => setDirectRunArgsInput(item.method.name, value)"
+                    @validate="markers => setDirectRunArgsValidation(item.method.name, markers)"
+                  />
 
-      <p
-        v-else-if="selectedProviderError"
-        class="direct-run-panel__message direct-run-panel__message--error"
-      >
-        {{ selectedProviderError }}
-      </p>
+                  <template #fallback>
+                    <div class="direct-run-drawer__editor-placeholder">
+                      Loading editor...
+                    </div>
+                  </template>
+                </ClientOnly>
 
-      <div
-        v-if="selectedProviderSnapshot"
-        class="direct-run-panel__result"
-      >
-        <p class="direct-run-panel__result-title">
-          Last run · {{ selectedProviderSnapshot.method }}()
-        </p>
-        <p class="direct-run-panel__message">
-          {{ selectedProviderSnapshot.summary }}
-        </p>
-        <p
-          v-if="selectedProviderLastRunLabel"
-          class="direct-run-panel__timestamp"
-        >
-          {{ selectedProviderLastRunLabel }}
-        </p>
-      </div>
-    </div>
+                <p
+                  v-if="getDirectRunArgsError(item.method)"
+                  class="direct-run-drawer__message direct-run-drawer__message--error"
+                >
+                  {{ getDirectRunArgsError(item.method) }}
+                </p>
+
+                <UButton
+                  type="button"
+                  :label="`Direct Run ${item.method.name}()`"
+                  icon="i-lucide-play"
+                  color="primary"
+                  block
+                  :loading="selectedProviderPendingMethod === item.method.name"
+                  :disabled="isDirectRunActionDisabled(item.method)"
+                  @click="requestDirectRun(item.method)"
+                />
+              </div>
+            </template>
+          </UTabs>
+
+          <p
+            v-if="selectedProviderPendingMethod"
+            class="direct-run-drawer__message"
+          >
+            Running {{ selectedProviderPendingMethod }}()...
+          </p>
+
+          <p
+            v-else-if="selectedProviderError"
+            class="direct-run-drawer__message direct-run-drawer__message--error"
+          >
+            {{ selectedProviderError }}
+          </p>
+
+          <div
+            v-if="selectedProviderSnapshot"
+            class="direct-run-drawer__result"
+          >
+            <p class="direct-run-drawer__result-title">
+              Last run · {{ selectedProviderSnapshot.method }}()
+            </p>
+            <p class="direct-run-drawer__message">
+              {{ selectedProviderSnapshot.summary }}
+            </p>
+            <p
+              v-if="selectedProviderLastRunLabel"
+              class="direct-run-drawer__timestamp"
+            >
+              {{ selectedProviderLastRunLabel }}
+            </p>
+          </div>
+        </div>
+      </template>
+    </UDrawer>
 
     <UDrawer
       v-model:open="showCircularDetailDialog"
@@ -2548,40 +3167,40 @@ useResizeObserver(graphViewerRef, () => {
   pointer-events: none;
 }
 
-.direct-run-panel {
-  position: absolute;
-  left: 12px;
-  bottom: 12px;
-  z-index: 10;
-  width: min(360px, calc(100% - 24px));
-  padding: 12px;
-  border: 1px solid var(--mg-subgraph-title-border);
-  border-radius: 12px;
-  background: color-mix(in srgb, var(--ui-bg) 96%, transparent);
-  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.16);
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  font-family: 'Public Sans', system-ui, sans-serif;
-}
-
-.direct-run-panel__header {
+.direct-run-drawer__header {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
   gap: 12px;
+  width: 100%;
 }
 
-.direct-run-panel__eyebrow,
-.direct-run-panel__subtitle,
-.direct-run-panel__timestamp,
-.direct-run-panel__message,
-.direct-run-panel__result-title,
-.direct-run-panel__title {
+.direct-run-drawer__header-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.direct-run-drawer__body,
+.direct-run-drawer__method,
+.direct-run-drawer__result {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.direct-run-drawer__eyebrow,
+.direct-run-drawer__method-name,
+.direct-run-drawer__method-subtitle,
+.direct-run-drawer__subtitle,
+.direct-run-drawer__timestamp,
+.direct-run-drawer__message,
+.direct-run-drawer__result-title,
+.direct-run-drawer__title {
   margin: 0;
 }
 
-.direct-run-panel__eyebrow {
+.direct-run-drawer__eyebrow {
   font-size: 11px;
   font-weight: 700;
   letter-spacing: 0.08em;
@@ -2589,44 +3208,62 @@ useResizeObserver(graphViewerRef, () => {
   color: var(--ui-text-muted);
 }
 
-.direct-run-panel__title {
+.direct-run-drawer__title {
   font-size: 14px;
   font-weight: 700;
   color: var(--ui-text-highlighted);
+  overflow-wrap: anywhere;
 }
 
-.direct-run-panel__subtitle,
-.direct-run-panel__timestamp {
+.direct-run-drawer__subtitle,
+.direct-run-drawer__method-subtitle,
+.direct-run-drawer__timestamp {
   font-size: 12px;
   color: var(--ui-text-muted);
 }
 
-.direct-run-panel__actions {
+.direct-run-drawer__method-header {
   display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
 }
 
-.direct-run-panel__message {
+.direct-run-drawer__method-name {
+  min-width: 0;
+  color: var(--ui-text-highlighted);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', monospace;
+  font-size: 13px;
+  overflow-wrap: anywhere;
+}
+
+.direct-run-drawer__editor-placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 240px;
+  border: 1px solid var(--ui-border);
+  border-radius: 8px;
+  color: var(--ui-text-muted);
+  font-size: 13px;
+}
+
+.direct-run-drawer__message {
   font-size: 13px;
   line-height: 1.45;
   color: var(--ui-text);
   overflow-wrap: anywhere;
 }
 
-.direct-run-panel__message--error {
+.direct-run-drawer__message--error {
   color: var(--ui-error);
 }
 
-.direct-run-panel__result {
-  padding-top: 2px;
-  border-top: 1px solid var(--mg-subgraph-title-border);
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
+.direct-run-drawer__result {
+  width: 100%;
 }
 
-.direct-run-panel__result-title {
+.direct-run-drawer__result-title {
   font-size: 12px;
   font-weight: 600;
   color: var(--ui-text-highlighted);

--- a/site/app/components/GraphViewer.vue
+++ b/site/app/components/GraphViewer.vue
@@ -22,11 +22,17 @@ import type {
   GraphOutputDependencyRef,
   GraphOutputCycle,
   GraphOutputProviderCycle,
-  GraphOutputCycles
+  GraphOutputCycles,
+  GraphOutputProvider
 } from '@library/libs/nest-graph-inspector/src/types/graph-output.type'
 import type { CircularDependencyIssue } from '~/utils/circular-dependency-issues'
 import { buildCircularIssueFlow } from '~/utils/circular-dependency-flow'
 import { resolveCircularDependencyEndpoints } from '~/utils/circular-dependency-issues'
+import {
+  getDirectRunProviderState,
+  parseProviderNodeId,
+  type DirectRunExecutionSnapshot
+} from '~/utils/direct-run-provider'
 
 function normalizeDep(dep: GraphOutputDependencyRef): {
   moduleName: string
@@ -48,6 +54,24 @@ type ItemNodeData = {
   label: string
   kind: 'controller' | 'provider'
   isExported: boolean
+}
+
+type DirectRunActionRequest = {
+  moduleName: string
+  providerName: string
+  methodName: string
+}
+
+type DirectRunProviderContext = {
+  nodeId: string
+  moduleName: string
+  provider: GraphOutputProvider
+}
+
+type DirectRunStatusBadge = {
+  label: string
+  color: 'neutral' | 'primary' | 'success' | 'error'
+  variant: 'soft' | 'solid' | 'outline'
 }
 
 type ModuleItemLayout = ItemNodeData & {
@@ -100,6 +124,10 @@ type FlowEdge = Edge<
 type WarningEdgeProps = EdgeProps<CircularEdgeData>
 type NodePosition = { x: number, y: number }
 
+const emit = defineEmits<{
+  directRun: [request: DirectRunActionRequest]
+}>()
+
 const props = withDefaults(
   defineProps<{
     data: GraphOutput
@@ -112,6 +140,16 @@ const props = withDefaults(
     excludeModules?: string[] | string
     enableBrightLine?: boolean
     collapsedModules?: string[] | string
+    directRunResult?: {
+      moduleName: string
+      providerName: string
+      snapshot: DirectRunExecutionSnapshot
+    } | null
+    directRunError?: {
+      moduleName: string
+      providerName: string
+      error: string
+    } | null
   }>(),
   {
     height: '75vh',
@@ -1314,6 +1352,10 @@ const hasInitialFixedBrightLine = props.enableBrightLine
 const showModuleToModuleLine = ref(!hasInitialFixedBrightLine)
 const showProviderToProviderInsideModule = ref(!hasInitialFixedBrightLine)
 const showProviderToProviderAcrossModule = ref(false)
+const directRunStateByNodeId = ref<Record<string, DirectRunExecutionSnapshot>>({})
+const selectedProviderNodeId = ref<string | null>(null)
+const directRunPendingMethodByNodeId = ref<Record<string, string>>({})
+const directRunErrorByNodeId = ref<Record<string, string>>({})
 const initialGraph = buildGraph(graphData.value, collapsedModuleNames.value, {
   showCircularDependencies: showCircularDependencies.value,
   showModuleToModuleLine: showModuleToModuleLine.value,
@@ -1402,6 +1444,103 @@ const allModulesOpenState = computed<boolean | 'indeterminate'>(() => {
   }
 
   return 'indeterminate'
+})
+const selectedProviderContext = computed<DirectRunProviderContext | null>(() => {
+  const nodeId = selectedProviderNodeId.value
+  if (!nodeId) {
+    return null
+  }
+
+  const parsed = parseProviderNodeId(nodeId)
+  if (!parsed) {
+    return null
+  }
+
+  const provider = graphData.value.modules[parsed.moduleName]?.providers
+    .find(item => item.name === parsed.providerName)
+
+  if (!provider) {
+    return null
+  }
+
+  return {
+    nodeId,
+    moduleName: parsed.moduleName,
+    provider
+  }
+})
+const selectedProviderDirectRunState = computed(() => {
+  const context = selectedProviderContext.value
+  return context ? getDirectRunProviderState(context.provider) : null
+})
+const selectedProviderSnapshot = computed(() => {
+  const nodeId = selectedProviderContext.value?.nodeId
+  return nodeId ? directRunStateByNodeId.value[nodeId] || null : null
+})
+const selectedProviderPendingMethod = computed(() => {
+  const nodeId = selectedProviderContext.value?.nodeId
+  return nodeId ? directRunPendingMethodByNodeId.value[nodeId] || '' : ''
+})
+const selectedProviderError = computed(() => {
+  const nodeId = selectedProviderContext.value?.nodeId
+  return nodeId ? directRunErrorByNodeId.value[nodeId] || '' : ''
+})
+const selectedProviderLastRunLabel = computed(() => {
+  const value = selectedProviderSnapshot.value?.updatedAt
+  if (!value) {
+    return ''
+  }
+
+  return new Date(value).toLocaleString()
+})
+const selectedProviderStatusBadge = computed<DirectRunStatusBadge | null>(() => {
+  const context = selectedProviderContext.value
+  if (!context) {
+    return null
+  }
+
+  const directRunState = selectedProviderDirectRunState.value
+  if (!directRunState) {
+    return null
+  }
+
+  if (!directRunState.runnable) {
+    return {
+      label: 'Not runnable',
+      color: 'neutral',
+      variant: 'outline'
+    }
+  }
+
+  const pendingMethod = selectedProviderPendingMethod.value
+  if (pendingMethod) {
+    return {
+      label: 'Running',
+      color: 'primary',
+      variant: 'solid'
+    }
+  }
+
+  const snapshot = selectedProviderSnapshot.value
+  if (!snapshot) {
+    return {
+      label: 'Idle',
+      color: 'neutral',
+      variant: 'soft'
+    }
+  }
+
+  return snapshot.state === 'success'
+    ? {
+        label: 'Success',
+        color: 'success',
+        variant: 'solid'
+      }
+    : {
+        label: 'Failed',
+        color: 'error',
+        variant: 'solid'
+      }
 })
 
 function resolveBrightLineNodeId(target: string): string | null {
@@ -1514,6 +1653,90 @@ function clearActiveBrightLineNode(event?: NodeMouseEvent): void {
   }
 }
 
+function selectProviderNode(nodeId: string | null): void {
+  if (nodeId && parseProviderNodeId(nodeId)) {
+    selectedProviderNodeId.value = nodeId
+    return
+  }
+
+  selectedProviderNodeId.value = null
+}
+
+function handleNodeClick(event: NodeMouseEvent): void {
+  selectProviderNode(event.node.id)
+}
+
+function clearDirectRunPending(nodeId: string): void {
+  const { [nodeId]: _removed, ...nextPendingState } = directRunPendingMethodByNodeId.value
+  directRunPendingMethodByNodeId.value = nextPendingState
+}
+
+function setDirectRunError(nodeId: string, error: string): void {
+  directRunErrorByNodeId.value = {
+    ...directRunErrorByNodeId.value,
+    [nodeId]: error
+  }
+}
+
+function clearDirectRunError(nodeId: string): void {
+  const { [nodeId]: _removed, ...nextErrorState } = directRunErrorByNodeId.value
+  directRunErrorByNodeId.value = nextErrorState
+}
+
+async function emitDirectRun(request: DirectRunActionRequest): Promise<void> {
+  const nodeId = `provider-${request.moduleName}-${request.providerName}`
+  directRunPendingMethodByNodeId.value = {
+    ...directRunPendingMethodByNodeId.value,
+    [nodeId]: request.methodName
+  }
+  clearDirectRunError(nodeId)
+
+  try {
+    await Promise.resolve()
+    emit('directRun', request)
+  } catch (error) {
+    clearDirectRunPending(nodeId)
+    setDirectRunError(nodeId, error instanceof Error ? error.message : 'Direct run failed.')
+  }
+}
+
+function applyDirectRunResult(payload: {
+  moduleName: string
+  providerName: string
+  snapshot: DirectRunExecutionSnapshot
+}): void {
+  const nodeId = `provider-${payload.moduleName}-${payload.providerName}`
+  directRunStateByNodeId.value = {
+    ...directRunStateByNodeId.value,
+    [nodeId]: payload.snapshot
+  }
+  clearDirectRunPending(nodeId)
+  clearDirectRunError(nodeId)
+}
+
+function applyDirectRunFailure(payload: {
+  moduleName: string
+  providerName: string
+  error: string
+}): void {
+  const nodeId = `provider-${payload.moduleName}-${payload.providerName}`
+  clearDirectRunPending(nodeId)
+  setDirectRunError(nodeId, payload.error)
+}
+
+function requestDirectRun(methodName: string): void {
+  const context = selectedProviderContext.value
+  if (!context) {
+    return
+  }
+
+  void emitDirectRun({
+    moduleName: context.moduleName,
+    providerName: context.provider.name,
+    methodName
+  })
+}
+
 function openCircularTooltip(edgeId: string): void {
   activeCircularTooltipEdgeId.value = edgeId
 }
@@ -1558,6 +1781,9 @@ function refreshGraph(options: { preservePositions?: boolean } = {}) {
 
   activeCircularTooltipEdgeId.value = null
   activeBrightLineNodeId.value = null
+  if (selectedProviderNodeId.value && !flowNodes.value.some(node => node.id === selectedProviderNodeId.value)) {
+    selectedProviderNodeId.value = null
+  }
   showCircularDetailDialog.value = false
   circularDetailDialogData.value = null
   const graph = buildGraph(graphData.value, collapsedModuleNames.value, {
@@ -1654,6 +1880,30 @@ watch(
     collapsedModuleNames.value = getInitialCollapsedModuleNames(graphData.value)
     refreshGraph({ preservePositions: false })
     void centerGraph()
+  },
+  { deep: true }
+)
+
+watch(
+  () => props.directRunResult,
+  (payload) => {
+    if (!payload) {
+      return
+    }
+
+    applyDirectRunResult(payload)
+  },
+  { deep: true }
+)
+
+watch(
+  () => props.directRunError,
+  (payload) => {
+    if (!payload) {
+      return
+    }
+
+    applyDirectRunFailure(payload)
   },
   { deep: true }
 )
@@ -1816,6 +2066,8 @@ useResizeObserver(graphViewerRef, () => {
       class="graph-flow"
       @node-mouse-enter="setActiveBrightLineNode"
       @node-mouse-leave="clearActiveBrightLineNode"
+      @node-click="handleNodeClick"
+      @pane-click="selectProviderNode(null)"
     >
       <template #edge-warning="edgeProps">
         <BaseEdge
@@ -2028,6 +2280,88 @@ useResizeObserver(graphViewerRef, () => {
       <MiniMap v-if="props.interactive" />
     </VueFlow>
 
+    <div
+      v-if="selectedProviderContext"
+      class="direct-run-panel nodrag nopan"
+      aria-label="Direct run provider panel"
+    >
+      <div class="direct-run-panel__header">
+        <div class="min-w-0">
+          <p class="direct-run-panel__eyebrow">
+            Provider Action
+          </p>
+          <p class="direct-run-panel__title">
+            {{ selectedProviderContext.provider.name }}
+          </p>
+          <p class="direct-run-panel__subtitle">
+            {{ selectedProviderContext.moduleName }}
+          </p>
+        </div>
+        <UBadge
+          v-if="selectedProviderStatusBadge"
+          :label="selectedProviderStatusBadge.label"
+          :color="selectedProviderStatusBadge.color"
+          :variant="selectedProviderStatusBadge.variant"
+        />
+      </div>
+
+      <p
+        v-if="selectedProviderDirectRunState && !selectedProviderDirectRunState.runnable"
+        class="direct-run-panel__message"
+      >
+        {{ selectedProviderDirectRunState.reason }}
+      </p>
+
+      <div
+        v-else-if="selectedProviderDirectRunState"
+        class="direct-run-panel__actions"
+      >
+        <UButton
+          v-for="method in selectedProviderDirectRunState.methods"
+          :key="method.name"
+          type="button"
+          :label="`Direct Run ${method.name}()`"
+          icon="i-lucide-play"
+          color="primary"
+          :loading="selectedProviderPendingMethod === method.name"
+          :disabled="Boolean(selectedProviderPendingMethod)"
+          @click="requestDirectRun(method.name)"
+        />
+      </div>
+
+      <p
+        v-if="selectedProviderPendingMethod"
+        class="direct-run-panel__message"
+      >
+        Running {{ selectedProviderPendingMethod }}()…
+      </p>
+
+      <p
+        v-else-if="selectedProviderError"
+        class="direct-run-panel__message direct-run-panel__message--error"
+      >
+        {{ selectedProviderError }}
+      </p>
+
+      <div
+        v-if="selectedProviderSnapshot"
+        class="direct-run-panel__result"
+      >
+        <p class="direct-run-panel__result-title">
+          Last run · {{ selectedProviderSnapshot.method }}()
+        </p>
+        <p class="direct-run-panel__message">
+          {{ selectedProviderSnapshot.summary }}
+        </p>
+        <p
+          v-if="selectedProviderLastRunLabel"
+          class="direct-run-panel__timestamp"
+        >
+          {{ selectedProviderLastRunLabel }}
+        </p>
+      </div>
+    </div>
+
     <UDrawer
       v-model:open="showCircularDetailDialog"
       side="right"
@@ -2212,6 +2546,90 @@ useResizeObserver(graphViewerRef, () => {
   gap: 8px;
   font-family: 'Public Sans', system-ui, sans-serif;
   pointer-events: none;
+}
+
+.direct-run-panel {
+  position: absolute;
+  left: 12px;
+  bottom: 12px;
+  z-index: 10;
+  width: min(360px, calc(100% - 24px));
+  padding: 12px;
+  border: 1px solid var(--mg-subgraph-title-border);
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--ui-bg) 96%, transparent);
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.16);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  font-family: 'Public Sans', system-ui, sans-serif;
+}
+
+.direct-run-panel__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.direct-run-panel__eyebrow,
+.direct-run-panel__subtitle,
+.direct-run-panel__timestamp,
+.direct-run-panel__message,
+.direct-run-panel__result-title,
+.direct-run-panel__title {
+  margin: 0;
+}
+
+.direct-run-panel__eyebrow {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ui-text-muted);
+}
+
+.direct-run-panel__title {
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--ui-text-highlighted);
+}
+
+.direct-run-panel__subtitle,
+.direct-run-panel__timestamp {
+  font-size: 12px;
+  color: var(--ui-text-muted);
+}
+
+.direct-run-panel__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.direct-run-panel__message {
+  font-size: 13px;
+  line-height: 1.45;
+  color: var(--ui-text);
+  overflow-wrap: anywhere;
+}
+
+.direct-run-panel__message--error {
+  color: var(--ui-error);
+}
+
+.direct-run-panel__result {
+  padding-top: 2px;
+  border-top: 1px solid var(--mg-subgraph-title-border);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.direct-run-panel__result-title {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--ui-text-highlighted);
 }
 
 .graph-viewer-legends__title {

--- a/site/app/components/GraphViewer.vue
+++ b/site/app/components/GraphViewer.vue
@@ -86,6 +86,11 @@ type DirectRunMethodTab = {
 
 type DirectRunArgsJsonSchema = Monaco.json.JSONSchema
 type DirectRunEditorMarker = Monaco.editor.IMarker
+type DirectRunParameterInfo = {
+  name: string
+  type: string
+  schema: DirectRunArgsJsonSchema
+}
 type DirectRunArgsSchemaCacheEntry = {
   fingerprint: string
   schema: DirectRunArgsJsonSchema
@@ -1504,14 +1509,18 @@ const showDirectRunDrawer = computed({
   }
 })
 const directRunMethodTabs = computed<DirectRunMethodTab[]>(() =>
-  (selectedProviderDirectRunState.value?.methods || []).map(method => ({
-    label: method.name,
-    value: method.name,
-    method,
-    badge: method.parameterCount
-      ? `${method.parameterCount} ${method.parameterCount === 1 ? 'arg' : 'args'}`
-      : undefined
-  }))
+  (selectedProviderDirectRunState.value?.methods || []).map((method) => {
+    const parameterCount = getDirectRunParameterCount(method)
+
+    return {
+      label: method.name,
+      value: method.name,
+      method,
+      badge: parameterCount
+        ? `${parameterCount} ${parameterCount === 1 ? 'arg' : 'args'}`
+        : undefined
+    }
+  })
 )
 const selectedProviderSnapshot = computed(() => {
   const nodeId = selectedProviderContext.value?.nodeId
@@ -1743,53 +1752,64 @@ function directRunArgsKey(nodeId: string, methodName: string): string {
 }
 
 function getDirectRunMethodSignature(method: DirectRunProviderMethod): string {
-  const parameterCount = method.parameterCount || 0
-  if (parameterCount === 0) {
+  const parameters = getDirectRunParameterInfos(method)
+  if (parameters.length === 0) {
     return `${method.name}()`
   }
 
-  const args = getDirectRunParameterNames(method).join(', ')
+  const args = parameters.map(parameter => parameter.name).join(', ')
 
   return `${method.name}(${args})`
 }
 
-function getDirectRunParameterNames(method: DirectRunProviderMethod): string[] {
-  const parameterCount = method.parameterCount || 0
-  if (
-    method.parameterNames
-    && method.parameterNames.length === parameterCount
-  ) {
-    return method.parameterNames
-  }
-
-  return Array.from(
-    { length: parameterCount },
-    (_, index) => `arg${index + 1}`
-  )
+function getDirectRunParameterCount(method: DirectRunProviderMethod): number {
+  return getDirectRunParameterInfos(method).length
 }
 
-function getDirectRunParameterTypes(method: DirectRunProviderMethod): string[] {
-  const parameterCount = method.parameterCount || 0
-  if (
-    method.parameterTypes
-    && method.parameterTypes.length === parameterCount
-  ) {
-    return method.parameterTypes
+function getDirectRunParameterInfos(
+  method: DirectRunProviderMethod
+): DirectRunParameterInfo[] {
+  const parameterTypes = method.parameterTypes?.trim() || '[]'
+  const tupleBody = parseDirectRunTupleBody(parameterTypes)
+  if (!tupleBody) {
+    return []
   }
 
-  return Array.from({ length: parameterCount }, () => 'unknown')
+  return splitTopLevel(tupleBody, ',')
+    .map((parameter, index): DirectRunParameterInfo => {
+      const separatorIndex = findTopLevelSeparator(parameter, ':')
+      const rawName = separatorIndex >= 0
+        ? parameter.slice(0, separatorIndex).trim()
+        : `arg${index + 1}`
+      const type = separatorIndex >= 0
+        ? parameter.slice(separatorIndex + 1).trim() || 'unknown'
+        : parameter.trim() || 'unknown'
+      const name = sanitizeDirectRunParameterName(rawName) || `arg${index + 1}`
+
+      return {
+        name,
+        type,
+        schema: typeScriptTypeToJsonSchema(type)
+      }
+    })
 }
 
-function getDirectRunParameterSchemas(method: DirectRunProviderMethod): DirectRunArgsJsonSchema[] {
-  const parameterCount = method.parameterCount || 0
-  if (
-    method.parameterSchemas
-    && method.parameterSchemas.length === parameterCount
-  ) {
-    return method.parameterSchemas as DirectRunArgsJsonSchema[]
+function parseDirectRunTupleBody(parameterTypes: string): string {
+  const trimmed = stripOuterParens(parameterTypes.trim())
+  if (!trimmed.startsWith('[') || !trimmed.endsWith(']')) {
+    return ''
   }
 
-  return Array.from({ length: parameterCount }, () => ({}))
+  return trimmed.slice(1, -1).trim()
+}
+
+function sanitizeDirectRunParameterName(name: string): string {
+  return name
+    .replace(/^\.\.\./, '')
+    .replace(/^readonly\s+/, '')
+    .replace(/\?$/, '')
+    .replace(/^['"]|['"]$/g, '')
+    .trim()
 }
 
 function getDirectRunEditorPath(methodName: string): string {
@@ -1806,12 +1826,7 @@ function getDirectRunArgsSchema(method: DirectRunProviderMethod): DirectRunArgsJ
   const cacheKey = context
     ? directRunArgsKey(context.nodeId, method.name)
     : method.name
-  const fingerprint = JSON.stringify({
-    parameterCount: method.parameterCount || 0,
-    parameterNames: method.parameterNames || [],
-    parameterTypes: method.parameterTypes || [],
-    parameterSchemas: method.parameterSchemas || []
-  })
+  const fingerprint = method.parameterTypes || '[]'
   const cachedSchema = directRunArgsSchemaCache.get(cacheKey)
   if (cachedSchema?.fingerprint === fingerprint) {
     return cachedSchema.schema
@@ -1827,15 +1842,14 @@ function getDirectRunArgsSchema(method: DirectRunProviderMethod): DirectRunArgsJ
 }
 
 function buildDirectRunArgsSchema(method: DirectRunProviderMethod): DirectRunArgsJsonSchema {
-  const parameterCount = method.parameterCount || 0
-  const parameterNames = getDirectRunParameterNames(method)
-  const parameterTypes = getDirectRunParameterTypes(method)
-  const parameterSchemas = getDirectRunParameterSchemas(method)
+  const parameters = getDirectRunParameterInfos(method)
+  const parameterCount = parameters.length
 
   if (parameterCount <= 1) {
-    const parameterName = parameterNames[0] || 'argument'
-    const parameterType = parameterTypes[0] || 'unknown'
-    const parameterSchema = parameterSchemas[0] || {}
+    const parameter = parameters[0]
+    const parameterName = parameter?.name || 'argument'
+    const parameterType = parameter?.type || 'unknown'
+    const parameterSchema = parameter?.schema || {}
 
     return {
       $schema: 'http://json-schema.org/draft-07/schema#',
@@ -1852,15 +1866,328 @@ function buildDirectRunArgsSchema(method: DirectRunProviderMethod): DirectRunArg
     type: 'array',
     minItems: parameterCount,
     maxItems: parameterCount,
-    items: Array.from(
-      { length: parameterCount },
-      (_, index): DirectRunArgsJsonSchema => ({
-        title: parameterNames[index] || `arg${index + 1}`,
-        description: parameterTypes[index] || 'unknown',
-        ...(parameterSchemas[index] || {})
-      })
-    )
+    items: parameters.map((parameter): DirectRunArgsJsonSchema => ({
+      title: parameter.name,
+      description: parameter.type,
+      ...parameter.schema
+    }))
   }
+}
+
+function typeScriptTypeToJsonSchema(typeText: string): DirectRunArgsJsonSchema {
+  const type = stripOuterParens(typeText.trim())
+  if (!type || type === 'unknown' || type === 'any') {
+    return {}
+  }
+
+  if (type === 'string') {
+    return { type: 'string' }
+  }
+  if (type === 'number') {
+    return { type: 'number' }
+  }
+  if (type === 'boolean') {
+    return { type: 'boolean' }
+  }
+  if (type === 'null') {
+    return { type: 'null' }
+  }
+  if (type === 'object') {
+    return { type: 'object' }
+  }
+
+  const literal = parseTypeScriptLiteral(type)
+  if (literal.matched) {
+    return { enum: [literal.value] }
+  }
+
+  const rawUnionTypes = splitTopLevel(type, '|')
+  const unionTypes = rawUnionTypes
+    .map(candidate => candidate.trim())
+    .filter(candidate => candidate && candidate !== 'undefined' && candidate !== 'void')
+  if (rawUnionTypes.length > 1) {
+    if (unionTypes.length === 1) {
+      return typeScriptTypeToJsonSchema(unionTypes[0] || 'unknown')
+    }
+
+    const literals = unionTypes.map(parseTypeScriptLiteral)
+    if (literals.every(candidate => candidate.matched)) {
+      return { enum: literals.map(candidate => candidate.value) }
+    }
+
+    return {
+      anyOf: unionTypes.map(candidate => typeScriptTypeToJsonSchema(candidate))
+    }
+  }
+
+  if (isArrayType(type)) {
+    return {
+      type: 'array',
+      items: typeScriptTypeToJsonSchema(type.slice(0, -2))
+    }
+  }
+
+  if (type.startsWith('[') && type.endsWith(']')) {
+    const tupleItems = splitTopLevel(type.slice(1, -1), ',')
+      .map(item => typeScriptTypeToJsonSchema(item))
+
+    return {
+      type: 'array',
+      minItems: tupleItems.length,
+      maxItems: tupleItems.length,
+      items: tupleItems
+    }
+  }
+
+  if (type.startsWith('{') && type.endsWith('}')) {
+    return objectTypeToJsonSchema(type.slice(1, -1))
+  }
+
+  return {}
+}
+
+function objectTypeToJsonSchema(typeBody: string): DirectRunArgsJsonSchema {
+  const properties: Record<string, DirectRunArgsJsonSchema> = {}
+  const required: string[] = []
+
+  for (const member of splitTopLevelAny(typeBody, [';', ','])) {
+    const separatorIndex = findTopLevelSeparator(member, ':')
+    if (separatorIndex <= 0) {
+      continue
+    }
+
+    const rawName = member.slice(0, separatorIndex).trim()
+    const propertyType = member.slice(separatorIndex + 1).trim()
+    const optional = rawName.endsWith('?')
+    const name = sanitizeDirectRunParameterName(rawName)
+    if (!name) {
+      continue
+    }
+
+    properties[name] = typeScriptTypeToJsonSchema(propertyType)
+    if (!optional && !typeIncludesUndefined(propertyType)) {
+      required.push(name)
+    }
+  }
+
+  return {
+    type: 'object',
+    additionalProperties: true,
+    properties,
+    required
+  }
+}
+
+function stripOuterParens(value: string): string {
+  let next = value.trim()
+  while (next.startsWith('(') && next.endsWith(')') && enclosesWholeValue(next)) {
+    next = next.slice(1, -1).trim()
+  }
+
+  return next
+}
+
+function enclosesWholeValue(value: string): boolean {
+  let depth = 0
+  let quote: string | null = null
+  let escaped = false
+
+  for (let index = 0; index < value.length; index += 1) {
+    const character = value[index]
+    if (quote) {
+      if (escaped) {
+        escaped = false
+      } else if (character === '\\') {
+        escaped = true
+      } else if (character === quote) {
+        quote = null
+      }
+      continue
+    }
+
+    if (character === '"' || character === "'" || character === '`') {
+      quote = character
+      continue
+    }
+    if (character === '(') {
+      depth += 1
+    } else if (character === ')') {
+      depth -= 1
+      if (depth === 0 && index < value.length - 1) {
+        return false
+      }
+    }
+  }
+
+  return depth === 0
+}
+
+function splitTopLevel(value: string, separator: string): string[] {
+  return splitTopLevelAny(value, [separator])
+}
+
+function splitTopLevelAny(value: string, separators: string[]): string[] {
+  const parts: string[] = []
+  let start = 0
+  let angleDepth = 0
+  let braceDepth = 0
+  let bracketDepth = 0
+  let parenDepth = 0
+  let quote: string | null = null
+  let escaped = false
+
+  for (let index = 0; index < value.length; index += 1) {
+    const character = value[index]
+    if (quote) {
+      if (escaped) {
+        escaped = false
+      } else if (character === '\\') {
+        escaped = true
+      } else if (character === quote) {
+        quote = null
+      }
+      continue
+    }
+
+    if (character === '"' || character === "'" || character === '`') {
+      quote = character
+      continue
+    }
+
+    if (character === '{') {
+      braceDepth += 1
+    } else if (character === '}') {
+      braceDepth -= 1
+    } else if (character === '[') {
+      bracketDepth += 1
+    } else if (character === ']') {
+      bracketDepth -= 1
+    } else if (character === '(') {
+      parenDepth += 1
+    } else if (character === ')') {
+      parenDepth -= 1
+    } else if (character === '<') {
+      angleDepth += 1
+    } else if (character === '>') {
+      angleDepth -= 1
+    } else if (
+      separators.includes(character)
+      && angleDepth === 0
+      && braceDepth === 0
+      && bracketDepth === 0
+      && parenDepth === 0
+    ) {
+      const part = value.slice(start, index).trim()
+      if (part) {
+        parts.push(part)
+      }
+      start = index + 1
+    }
+  }
+
+  const part = value.slice(start).trim()
+  if (part) {
+    parts.push(part)
+  }
+
+  return parts
+}
+
+function findTopLevelSeparator(value: string, separator: string): number {
+  let angleDepth = 0
+  let braceDepth = 0
+  let bracketDepth = 0
+  let parenDepth = 0
+  let quote: string | null = null
+  let escaped = false
+
+  for (let index = 0; index < value.length; index += 1) {
+    const character = value[index]
+    if (quote) {
+      if (escaped) {
+        escaped = false
+      } else if (character === '\\') {
+        escaped = true
+      } else if (character === quote) {
+        quote = null
+      }
+      continue
+    }
+
+    if (character === '"' || character === "'" || character === '`') {
+      quote = character
+      continue
+    }
+
+    if (character === '{') {
+      braceDepth += 1
+    } else if (character === '}') {
+      braceDepth -= 1
+    } else if (character === '[') {
+      bracketDepth += 1
+    } else if (character === ']') {
+      bracketDepth -= 1
+    } else if (character === '(') {
+      parenDepth += 1
+    } else if (character === ')') {
+      parenDepth -= 1
+    } else if (character === '<') {
+      angleDepth += 1
+    } else if (character === '>') {
+      angleDepth -= 1
+    } else if (
+      character === separator
+      && angleDepth === 0
+      && braceDepth === 0
+      && bracketDepth === 0
+      && parenDepth === 0
+    ) {
+      return index
+    }
+  }
+
+  return -1
+}
+
+function parseTypeScriptLiteral(
+  value: string
+): { matched: true, value: unknown } | { matched: false } {
+  if (/^'(?:\\.|[^'\\])*'$/.test(value) || /^"(?:\\.|[^"\\])*"$/.test(value)) {
+    try {
+      const normalizedValue = value.startsWith("'")
+        ? `"${value.slice(1, -1).replace(/"/g, '\\"')}"`
+        : value
+
+      return { matched: true, value: JSON.parse(normalizedValue) }
+    } catch {
+      return { matched: true, value: value.slice(1, -1) }
+    }
+  }
+
+  if (/^-?\d+(?:\.\d+)?$/.test(value)) {
+    return { matched: true, value: Number(value) }
+  }
+  if (value === 'true') {
+    return { matched: true, value: true }
+  }
+  if (value === 'false') {
+    return { matched: true, value: false }
+  }
+  if (value === 'null') {
+    return { matched: true, value: null }
+  }
+
+  return { matched: false }
+}
+
+function isArrayType(type: string): boolean {
+  return type.endsWith('[]') && stripOuterParens(type.slice(0, -2)).length > 0
+}
+
+function typeIncludesUndefined(type: string): boolean {
+  return splitTopLevel(type, '|').some(candidate =>
+    candidate.trim() === 'undefined'
+  )
 }
 
 function getDirectRunArgsInput(methodName: string): string {
@@ -1915,7 +2242,7 @@ function isDirectRunActionDisabled(method: DirectRunProviderMethod): boolean {
     return true
   }
 
-  if (!method.parameterCount) {
+  if (getDirectRunParameterCount(method) === 0) {
     return false
   }
 
@@ -1959,7 +2286,7 @@ function parseDirectRunArgs(
   method: DirectRunProviderMethod,
   input: string
 ): { ok: true, args: unknown[] | undefined } | { ok: false, error: string } {
-  const parameterCount = method.parameterCount || 0
+  const parameterCount = getDirectRunParameterCount(method)
   if (parameterCount === 0) {
     return { ok: true, args: undefined }
   }
@@ -2010,19 +2337,18 @@ function validateDirectRunParsedArgs(
   method: DirectRunProviderMethod,
   args: unknown[]
 ): string {
-  const parameterCount = method.parameterCount || 0
+  const parameters = getDirectRunParameterInfos(method)
+  const parameterCount = parameters.length
   if (args.length !== parameterCount) {
     return `${method.name}() expects ${parameterCount} arguments.`
   }
 
-  const parameterNames = getDirectRunParameterNames(method)
-  const parameterSchemas = getDirectRunParameterSchemas(method)
-
   for (let index = 0; index < parameterCount; index += 1) {
+    const parameter = parameters[index]
     const error = validateJsonSchemaValue(
       args[index],
-      parameterSchemas[index] || {},
-      parameterNames[index] || `arg${index + 1}`
+      parameter?.schema || {},
+      parameter?.name || `arg${index + 1}`
     )
     if (error) {
       return error
@@ -2893,21 +3219,21 @@ useResizeObserver(graphViewerRef, () => {
                       {{ getDirectRunMethodSignature(item.method) }}
                     </p>
                     <p
-                      v-if="item.method.parameterCount"
+                      v-if="getDirectRunParameterCount(item.method)"
                       class="direct-run-drawer__method-subtitle"
                     >
                       JSON arguments
                     </p>
                   </div>
                   <UBadge
-                    v-if="item.method.parameterCount"
-                    :label="`${item.method.parameterCount} ${item.method.parameterCount === 1 ? 'arg' : 'args'}`"
+                    v-if="getDirectRunParameterCount(item.method)"
+                    :label="`${getDirectRunParameterCount(item.method)} ${getDirectRunParameterCount(item.method) === 1 ? 'arg' : 'args'}`"
                     color="neutral"
                     variant="soft"
                   />
                 </div>
 
-                <ClientOnly v-if="item.method.parameterCount">
+                <ClientOnly v-if="getDirectRunParameterCount(item.method)">
                   <JsonMonacoEditor
                     :model-value="getDirectRunArgsInput(item.method.name)"
                     :path="getDirectRunEditorPath(item.method.name)"

--- a/site/app/components/JsonMonacoEditor.client.vue
+++ b/site/app/components/JsonMonacoEditor.client.vue
@@ -1,0 +1,208 @@
+<script setup lang="ts">
+import { VueMonacoEditor, loader } from '@guolao/vue-monaco-editor'
+import type { MonacoEditor } from '@guolao/vue-monaco-editor'
+import type * as Monaco from 'monaco-editor'
+
+type JsonSchema = Monaco.json.JSONSchema
+
+const model = defineModel<string>({ default: '' })
+const emit = defineEmits<{
+  validate: [markers: Monaco.editor.IMarker[]]
+}>()
+const props = withDefaults(
+  defineProps<{
+    height?: string
+    path?: string
+    readonly?: boolean
+    schema?: JsonSchema
+  }>(),
+  {
+    height: '220px',
+    path: undefined,
+    readonly: false,
+    schema: undefined
+  }
+)
+
+let isMonacoConfigured = false
+const MONACO_CDN_VERSION = '0.55.1'
+const registeredJsonSchemas = new Map<string, JsonSchema>()
+let activeMonaco: MonacoEditor | null = null
+const schemaFingerprint = computed(() =>
+  props.schema ? JSON.stringify(props.schema) : ''
+)
+
+function configureMonaco(): void {
+  if (isMonacoConfigured) {
+    return
+  }
+
+  loader.config({
+    paths: {
+      vs: `https://cdn.jsdelivr.net/npm/monaco-editor@${MONACO_CDN_VERSION}/min/vs`
+    }
+  })
+  isMonacoConfigured = true
+}
+
+configureMonaco()
+
+function getJsonSchemaUri(path: string): string {
+  return `json-monaco-editor://${encodeURIComponent(path)}.schema.json`
+}
+
+function applyJsonSchemas(monaco: MonacoEditor): void {
+  monaco.languages.json.jsonDefaults.setDiagnosticsOptions({
+    validate: true,
+    allowComments: false,
+    schemaValidation: 'error',
+    trailingCommas: 'error',
+    schemas: Array.from(registeredJsonSchemas.entries()).map(([path, schema]) => ({
+      uri: getJsonSchemaUri(path),
+      fileMatch: [path],
+      schema
+    }))
+  })
+}
+
+function syncJsonSchema(monaco: MonacoEditor): void {
+  if (props.path) {
+    if (props.schema) {
+      registeredJsonSchemas.set(props.path, props.schema)
+    } else {
+      registeredJsonSchemas.delete(props.path)
+    }
+  }
+
+  applyJsonSchemas(monaco)
+}
+
+function handleBeforeMount(monaco: MonacoEditor): void {
+  activeMonaco = monaco
+  syncJsonSchema(monaco)
+}
+
+function handleValidate(markers: Monaco.editor.IMarker[]): void {
+  emit('validate', markers)
+}
+
+watch(
+  [() => props.path, schemaFingerprint],
+  ([path], [previousPath]) => {
+    if (previousPath && previousPath !== path) {
+      registeredJsonSchemas.delete(previousPath)
+    }
+
+    if (activeMonaco) {
+      syncJsonSchema(activeMonaco)
+    }
+  }
+)
+
+onUnmounted(() => {
+  if (props.path) {
+    registeredJsonSchemas.delete(props.path)
+  }
+
+  if (activeMonaco) {
+    applyJsonSchemas(activeMonaco)
+  }
+})
+
+const editorOptions = computed(() =>
+  markRaw({
+    automaticLayout: true,
+    bracketPairColorization: {
+      enabled: true
+    },
+    folding: true,
+    fixedOverflowWidgets: true,
+    formatOnPaste: true,
+    formatOnType: true,
+    glyphMargin: false,
+    hover: {
+      above: false,
+      delay: 200,
+      sticky: true
+    },
+    insertSpaces: true,
+    lineDecorationsWidth: 12,
+    lineNumbers: 'on',
+    minimap: {
+      enabled: false
+    },
+    padding: {
+      top: 22,
+      bottom: 18
+    },
+    readOnly: props.readonly,
+    renderValidationDecorations: 'on',
+    renderLineHighlight: 'line',
+    scrollBeyondLastLine: false,
+    scrollbar: {
+      horizontalScrollbarSize: 10,
+      verticalScrollbarSize: 10
+    },
+    tabSize: 2,
+    wordWrap: 'on'
+  })
+)
+</script>
+
+<template>
+  <div class="json-monaco-editor">
+    <VueMonacoEditor
+      v-model:value="model"
+      language="json"
+      theme="vs-dark"
+      :path="props.path"
+      :height="props.height"
+      :options="editorOptions"
+      width="100%"
+      @before-mount="handleBeforeMount"
+      @validate="handleValidate"
+    >
+      <div class="json-monaco-editor__state">
+        Loading editor...
+      </div>
+
+      <template #failure>
+        <div class="json-monaco-editor__state json-monaco-editor__state--error">
+          Editor failed to load.
+        </div>
+      </template>
+    </VueMonacoEditor>
+  </div>
+</template>
+
+<style scoped>
+.json-monaco-editor {
+  overflow: visible;
+  border: 1px solid var(--ui-border);
+  border-radius: 8px;
+  background: #1e1e1e;
+}
+
+.json-monaco-editor :deep(.monaco-editor),
+.json-monaco-editor :deep(.overflow-guard) {
+  border-radius: 7px;
+}
+
+.json-monaco-editor :deep(.monaco-hover) {
+  max-width: calc(100vw - 48px);
+}
+
+.json-monaco-editor__state {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  min-height: 220px;
+  color: var(--ui-text-muted);
+  font-size: 13px;
+}
+
+.json-monaco-editor__state--error {
+  color: var(--ui-error);
+}
+</style>

--- a/site/app/components/content/RuntimeGraphDirectRunPreview.vue
+++ b/site/app/components/content/RuntimeGraphDirectRunPreview.vue
@@ -1,0 +1,88 @@
+<script setup lang="ts">
+import type { GraphOutput } from '@library/libs/nest-graph-inspector/src/types/graph-output.type'
+
+const config = useRuntimeConfig()
+let base = config.app.baseURL || '/'
+if (!base.endsWith('/')) {
+  base += '/'
+}
+
+const { data, status, error } = await useLazyAsyncData(
+  'runtime-graph-direct-run-preview',
+  () => $fetch<GraphOutput>(`${base}mock-graph/output.json`),
+  { server: false }
+)
+
+const previewData = computed<GraphOutput | null>(() => {
+  const userModule = data.value?.modules.UserModule
+  const userService = userModule?.providers.find(provider => provider.name === 'UserService')
+
+  if (!data.value || !userModule || !userService) {
+    return null
+  }
+
+  return {
+    ...data.value,
+    root: 'UserModule',
+    modules: {
+      UserModule: {
+        ...userModule,
+        imports: [],
+        exports: ['UserService'],
+        providers: [
+          {
+            ...userService,
+            dependencies: []
+          }
+        ],
+        controllers: []
+      }
+    },
+    cycles: {
+      modules: [],
+      providers: [],
+      controllers: []
+    }
+  }
+})
+
+const methods = computed(() => {
+  const provider = previewData.value?.modules.UserModule?.providers[0]
+  return provider?.directRun?.methods.slice(0, 3) || []
+})
+</script>
+
+<template>
+  <div class="grid gap-0 lg:grid-cols-[minmax(0,1fr)_20rem]">
+      <div class="min-h-80 border-b border-default lg:border-r lg:border-b-0">
+        <ClientOnly>
+          <GraphViewer
+            v-if="status === 'success' && previewData"
+            :data="previewData"
+            flow-id="runtime-graph-preview-direct-run"
+            height="clamp(18rem, 58vh, 34rem)"
+            :interactive="false"
+            :show-circular-dependencies="false"
+            :enable-bright-line="false"
+            default-open-module-detail
+          />
+          <UAlert
+            v-else-if="status === 'error'"
+            icon="i-lucide-triangle-alert"
+            color="error"
+            variant="subtle"
+            title="Could not load preview graph"
+            :description="error?.message || 'The mock graph endpoint is unavailable.'"
+          />
+          <USkeleton
+            v-else
+            class="h-80 w-full rounded-none"
+          />
+
+          <template #fallback>
+            <USkeleton class="h-80 w-full rounded-none" />
+          </template>
+        </ClientOnly>
+      </div>
+    </div>
+</template>

--- a/site/app/pages/view/[url]/index.vue
+++ b/site/app/pages/view/[url]/index.vue
@@ -5,6 +5,12 @@ import {
   resolveGraphViewerLoadSource,
   type LoadSource
 } from '~/utils/graph-viewer-analytics'
+import {
+  buildDirectRunRequest,
+  buildDirectRunSnapshot,
+  type DirectRunExecutionSnapshot,
+  type DirectRunResultPayload
+} from '~/utils/direct-run-provider'
 
 definePageMeta({
   layout: 'viewer'
@@ -21,6 +27,16 @@ const {
   showCircularDependencies,
   openModuleDetail
 } = storeToRefs(graphStore)
+const directRunResult = ref<{
+  moduleName: string
+  providerName: string
+  snapshot: DirectRunExecutionSnapshot
+} | null>(null)
+const directRunError = ref<{
+  moduleName: string
+  providerName: string
+  error: string
+} | null>(null)
 
 let hasTrackedInitialMount = false
 
@@ -106,6 +122,68 @@ watch(encodedUrl, (value) => {
 function handleRefresh() {
   loadGraphResources(encodedUrl.value, 'manual_refresh', true)
 }
+
+function resolveDirectRunUrl(): string {
+  const sourceUrl = decodedUrl.value
+  if (!sourceUrl) {
+    return ''
+  }
+
+  try {
+    const url = new URL(sourceUrl)
+    url.pathname = '/direct-run'
+    url.search = ''
+    url.hash = ''
+    return url.toString()
+  } catch {
+    return ''
+  }
+}
+
+async function handleDirectRun(request: {
+  moduleName: string
+  providerName: string
+  methodName: string
+}) {
+  directRunResult.value = null
+  directRunError.value = null
+
+  const directRunUrl = resolveDirectRunUrl()
+  if (!directRunUrl) {
+    directRunError.value = {
+      moduleName: request.moduleName,
+      providerName: request.providerName,
+      error: 'Direct run endpoint is unavailable for this graph URL.'
+    }
+    return
+  }
+
+  try {
+    const response = await $fetch<DirectRunResultPayload>(directRunUrl, {
+      method: 'POST',
+      body: buildDirectRunRequest(request)
+    })
+
+    directRunResult.value = {
+      moduleName: request.moduleName,
+      providerName: request.providerName,
+      snapshot: buildDirectRunSnapshot({
+        response,
+        requestedMethod: request.methodName
+      })
+    }
+  } catch (error) {
+    const message = error instanceof Error
+      ? error.message
+      : 'Direct run failed.'
+
+    directRunError.value = {
+      moduleName: request.moduleName,
+      providerName: request.providerName,
+      error: message
+    }
+  }
+}
 </script>
 
 <template>
@@ -178,8 +256,11 @@ function handleRefresh() {
       v-model:show-circular-dependencies="showCircularDependencies"
       :data="graphData"
       :default-open-module-detail="openModuleDetail"
+      :direct-run-result="directRunResult"
+      :direct-run-error="directRunError"
       height="100%"
       flush
+      @direct-run="handleDirectRun"
     />
   </ClientOnly>
 

--- a/site/app/pages/view/[url]/index.vue
+++ b/site/app/pages/view/[url]/index.vue
@@ -2,6 +2,7 @@
 import { storeToRefs } from 'pinia'
 import {
   createGraphViewerEventProperties,
+  resolveGraphViewerLoadSource,
   type LoadSource
 } from '~/utils/graph-viewer-analytics'
 
@@ -79,10 +80,6 @@ async function loadGraphResources(
   }
 
   if (graphLoaded) {
-    if (loadSource === 'initial_mount') {
-      hasTrackedInitialMount = true
-    }
-
     trackGraphViewerEvent('graph_viewer_load_succeeded', {
       loadSource,
       isRetry
@@ -101,7 +98,8 @@ async function loadGraphResources(
 }
 
 watch(encodedUrl, (value) => {
-  const loadSource: LoadSource = hasTrackedInitialMount ? 'route_change' : 'initial_mount'
+  const loadSource = resolveGraphViewerLoadSource(hasTrackedInitialMount)
+  hasTrackedInitialMount = true
   loadGraphResources(value, loadSource)
 }, { immediate: true })
 

--- a/site/app/pages/view/[url]/index.vue
+++ b/site/app/pages/view/[url]/index.vue
@@ -144,6 +144,7 @@ async function handleDirectRun(request: {
   moduleName: string
   providerName: string
   methodName: string
+  args?: unknown[]
 }) {
   directRunResult.value = null
   directRunError.value = null

--- a/site/app/pages/view/[url]/issues.vue
+++ b/site/app/pages/view/[url]/issues.vue
@@ -4,6 +4,7 @@ import { buildCircularIssueFlow } from '~/utils/circular-dependency-flow'
 import { collectCircularDependencyIssues } from '~/utils/circular-dependency-issues'
 import {
   createGraphViewerEventProperties,
+  resolveGraphViewerLoadSource,
   type LoadSource
 } from '~/utils/graph-viewer-analytics'
 
@@ -75,10 +76,6 @@ async function loadGraphResources(
   }
 
   if (graphLoaded) {
-    if (loadSource === 'initial_mount') {
-      hasTrackedInitialMount = true
-    }
-
     trackGraphViewerEvent('graph_viewer_load_succeeded', {
       loadSource,
       isRetry
@@ -97,7 +94,8 @@ async function loadGraphResources(
 }
 
 watch(encodedUrl, (value) => {
-  const loadSource: LoadSource = hasTrackedInitialMount ? 'route_change' : 'initial_mount'
+  const loadSource = resolveGraphViewerLoadSource(hasTrackedInitialMount)
+  hasTrackedInitialMount = true
   loadGraphResources(value, loadSource)
 }, { immediate: true })
 

--- a/site/app/utils/direct-run-provider.test.ts
+++ b/site/app/utils/direct-run-provider.test.ts
@@ -1,0 +1,61 @@
+import { strict as assert } from 'node:assert'
+import {
+  buildDirectRunRequest,
+  buildDirectRunSnapshot,
+  getDirectRunProviderState,
+  parseProviderNodeId,
+  summarizeDirectRunResult
+} from './direct-run-provider.ts'
+
+assert.deepEqual(parseProviderNodeId('provider-UserModule-UserService'), {
+  moduleName: 'UserModule',
+  providerName: 'UserService'
+})
+assert.equal(parseProviderNodeId('controller-UserModule-UserController'), null)
+
+assert.deepEqual(
+  getDirectRunProviderState({
+    directRun: { methods: [{ name: 'ping' }] }
+  }),
+  {
+    runnable: true,
+    reason: '',
+    methods: [{ name: 'ping' }]
+  }
+)
+assert.deepEqual(
+  getDirectRunProviderState({
+    directRun: { methods: [] }
+  }),
+  {
+    runnable: false,
+    reason: 'No zero-argument public methods available for direct run.',
+    methods: []
+  }
+)
+
+assert.deepEqual(buildDirectRunRequest({
+  moduleName: 'UserModule',
+  providerName: 'UserService',
+  methodName: 'ping'
+}), {
+  module: 'UserModule',
+  provider: 'UserService',
+  method: 'ping'
+})
+
+assert.equal(summarizeDirectRunResult({ ok: true, result: { pong: true } }), '{"pong":true}')
+assert.equal(summarizeDirectRunResult({ ok: true, result: undefined }), 'Completed with no return value.')
+assert.equal(summarizeDirectRunResult({ ok: false, error: 'boom' }), 'boom')
+assert.deepEqual(buildDirectRunSnapshot({
+  response: { ok: true, method: 'ping', result: { pong: true } },
+  requestedMethod: 'ping',
+  updatedAt: new Date('2026-06-28T10:00:00.000Z')
+}), {
+  state: 'success',
+  summary: '{"pong":true}',
+  method: 'ping',
+  updatedAt: '2026-06-28T10:00:00.000Z'
+})
+
+console.log('direct-run-provider.test.ts ok')

--- a/site/app/utils/direct-run-provider.test.ts
+++ b/site/app/utils/direct-run-provider.test.ts
@@ -15,12 +15,12 @@ assert.equal(parseProviderNodeId('controller-UserModule-UserController'), null)
 
 assert.deepEqual(
   getDirectRunProviderState({
-    directRun: { methods: [{ name: 'ping' }] }
+    directRun: { methods: [{ name: 'ping', parameterCount: 0 }] }
   }),
   {
     runnable: true,
     reason: '',
-    methods: [{ name: 'ping' }]
+    methods: [{ name: 'ping', parameterCount: 0 }]
   }
 )
 assert.deepEqual(
@@ -29,7 +29,7 @@ assert.deepEqual(
   }),
   {
     runnable: false,
-    reason: 'No zero-argument public methods available for direct run.',
+    reason: 'No public methods available for direct run.',
     methods: []
   }
 )
@@ -42,6 +42,28 @@ assert.deepEqual(buildDirectRunRequest({
   module: 'UserModule',
   provider: 'UserService',
   method: 'ping'
+})
+assert.deepEqual(buildDirectRunRequest({
+  moduleName: 'UserModule',
+  providerName: 'UserService',
+  methodName: 'find',
+  args: [{ id: 1 }]
+}), {
+  module: 'UserModule',
+  provider: 'UserService',
+  method: 'find',
+  args: { id: 1 }
+})
+assert.deepEqual(buildDirectRunRequest({
+  moduleName: 'UserModule',
+  providerName: 'UserService',
+  methodName: 'range',
+  args: [1, 10]
+}), {
+  module: 'UserModule',
+  provider: 'UserService',
+  method: 'range',
+  args: [1, 10]
 })
 
 assert.equal(summarizeDirectRunResult({ ok: true, result: { pong: true } }), '{"pong":true}')

--- a/site/app/utils/direct-run-provider.test.ts
+++ b/site/app/utils/direct-run-provider.test.ts
@@ -15,12 +15,12 @@ assert.equal(parseProviderNodeId('controller-UserModule-UserController'), null)
 
 assert.deepEqual(
   getDirectRunProviderState({
-    directRun: { methods: [{ name: 'ping', parameterCount: 0 }] }
+    directRun: { methods: [{ name: 'ping', parameterTypes: '[]' }] }
   }),
   {
     runnable: true,
     reason: '',
-    methods: [{ name: 'ping', parameterCount: 0 }]
+    methods: [{ name: 'ping', parameterTypes: '[]' }]
   }
 )
 assert.deepEqual(

--- a/site/app/utils/direct-run-provider.ts
+++ b/site/app/utils/direct-run-provider.ts
@@ -1,5 +1,11 @@
+type DirectRunJsonSchema = Record<string, unknown>
+
 export type DirectRunProviderMethod = {
   name: string
+  parameterCount?: number
+  parameterNames?: string[]
+  parameterTypes?: string[]
+  parameterSchemas?: DirectRunJsonSchema[]
 }
 
 export type DirectRunProviderState = {
@@ -25,6 +31,7 @@ export type DirectRunRequestPayload = {
   module: string
   provider: string
   method: string
+  args?: unknown
 }
 
 export type DirectRunExecutionState = 'idle' | 'running' | 'success' | 'failed'
@@ -36,7 +43,7 @@ export type DirectRunExecutionSnapshot = {
   updatedAt: string
 }
 
-const DIRECT_RUN_EMPTY_REASON = 'No zero-argument public methods available for direct run.'
+const DIRECT_RUN_EMPTY_REASON = 'No public methods available for direct run.'
 const DIRECT_RUN_SUMMARY_CHAR_LIMIT = 240
 
 export function parseProviderNodeId(nodeId: string): {
@@ -81,12 +88,19 @@ export function buildDirectRunRequest(payload: {
   moduleName: string
   providerName: string
   methodName: string
+  args?: unknown[]
 }): DirectRunRequestPayload {
-  return {
+  const request: DirectRunRequestPayload = {
     module: payload.moduleName,
     provider: payload.providerName,
     method: payload.methodName
   }
+
+  if (payload.args !== undefined) {
+    request.args = payload.args.length === 1 ? payload.args[0] : payload.args
+  }
+
+  return request
 }
 
 export function summarizeDirectRunResult(payload: DirectRunResultPayload): string {

--- a/site/app/utils/direct-run-provider.ts
+++ b/site/app/utils/direct-run-provider.ts
@@ -1,11 +1,6 @@
-type DirectRunJsonSchema = Record<string, unknown>
-
 export type DirectRunProviderMethod = {
   name: string
-  parameterCount?: number
-  parameterNames?: string[]
-  parameterTypes?: string[]
-  parameterSchemas?: DirectRunJsonSchema[]
+  parameterTypes: string
 }
 
 export type DirectRunProviderState = {

--- a/site/app/utils/direct-run-provider.ts
+++ b/site/app/utils/direct-run-provider.ts
@@ -1,0 +1,127 @@
+export type DirectRunProviderMethod = {
+  name: string
+}
+
+export type DirectRunProviderState = {
+  runnable: boolean
+  reason: string
+  methods: DirectRunProviderMethod[]
+}
+
+export type DirectRunResultPayload = {
+  ok: boolean
+  method?: string
+  result?: unknown
+  error?: string
+}
+
+export type DirectRunCapableProvider = {
+  directRun?: {
+    methods?: DirectRunProviderMethod[]
+  }
+}
+
+export type DirectRunRequestPayload = {
+  module: string
+  provider: string
+  method: string
+}
+
+export type DirectRunExecutionState = 'idle' | 'running' | 'success' | 'failed'
+
+export type DirectRunExecutionSnapshot = {
+  state: DirectRunExecutionState
+  summary: string
+  method: string
+  updatedAt: string
+}
+
+const DIRECT_RUN_EMPTY_REASON = 'No zero-argument public methods available for direct run.'
+const DIRECT_RUN_SUMMARY_CHAR_LIMIT = 240
+
+export function parseProviderNodeId(nodeId: string): {
+  moduleName: string
+  providerName: string
+} | null {
+  if (!nodeId.startsWith('provider-')) {
+    return null
+  }
+
+  const withoutPrefix = nodeId.slice('provider-'.length)
+  const separatorIndex = withoutPrefix.indexOf('-')
+  if (separatorIndex <= 0 || separatorIndex >= withoutPrefix.length - 1) {
+    return null
+  }
+
+  return {
+    moduleName: withoutPrefix.slice(0, separatorIndex),
+    providerName: withoutPrefix.slice(separatorIndex + 1)
+  }
+}
+
+export function getDirectRunProviderState(provider: DirectRunCapableProvider): DirectRunProviderState {
+  const methods = provider.directRun?.methods || []
+
+  if (!methods.length) {
+    return {
+      runnable: false,
+      reason: DIRECT_RUN_EMPTY_REASON,
+      methods: []
+    }
+  }
+
+  return {
+    runnable: true,
+    reason: '',
+    methods
+  }
+}
+
+export function buildDirectRunRequest(payload: {
+  moduleName: string
+  providerName: string
+  methodName: string
+}): DirectRunRequestPayload {
+  return {
+    module: payload.moduleName,
+    provider: payload.providerName,
+    method: payload.methodName
+  }
+}
+
+export function summarizeDirectRunResult(payload: DirectRunResultPayload): string {
+  if (!payload.ok) {
+    return payload.error || 'Direct run failed.'
+  }
+
+  if (payload.result === undefined) {
+    return 'Completed with no return value.'
+  }
+
+  const summary = safeJsonStringify(payload.result)
+  return summary.length > DIRECT_RUN_SUMMARY_CHAR_LIMIT
+    ? `${summary.slice(0, DIRECT_RUN_SUMMARY_CHAR_LIMIT - 1)}…`
+    : summary
+}
+
+export function buildDirectRunSnapshot(payload: {
+  response: DirectRunResultPayload
+  requestedMethod: string
+  updatedAt?: Date
+}): DirectRunExecutionSnapshot {
+  return {
+    state: payload.response.ok ? 'success' : 'failed',
+    summary: summarizeDirectRunResult(payload.response),
+    method: payload.response.method || payload.requestedMethod,
+    updatedAt: (payload.updatedAt || new Date()).toISOString()
+  }
+}
+
+function safeJsonStringify(value: unknown): string {
+  try {
+    const json = JSON.stringify(value)
+    return json === undefined ? String(value) : json
+  } catch {
+    return String(value)
+  }
+}

--- a/site/app/utils/graph-viewer-analytics.ts
+++ b/site/app/utils/graph-viewer-analytics.ts
@@ -1,5 +1,9 @@
 export type LoadSource = 'initial_mount' | 'route_change' | 'manual_refresh'
 
+export function resolveGraphViewerLoadSource(hasTrackedInitialMount: boolean): LoadSource {
+  return hasTrackedInitialMount ? 'route_change' : 'initial_mount'
+}
+
 function parseGraphUrl(graphUrl: string) {
   if (!graphUrl) {
     return {

--- a/site/app/utils/graph-viewer-load-source.test.ts
+++ b/site/app/utils/graph-viewer-load-source.test.ts
@@ -1,11 +1,7 @@
 import { strict as assert } from 'node:assert'
-import type { LoadSource } from './graph-viewer-analytics'
+import { resolveGraphViewerLoadSource } from './graph-viewer-analytics.ts'
 
-function resolveLoadSource(hasTrackedInitialMount: boolean): LoadSource {
-  return hasTrackedInitialMount ? 'route_change' : 'initial_mount'
-}
-
-assert.equal(resolveLoadSource(false), 'initial_mount')
-assert.equal(resolveLoadSource(true), 'route_change')
+assert.equal(resolveGraphViewerLoadSource(false), 'initial_mount')
+assert.equal(resolveGraphViewerLoadSource(true), 'route_change')
 
 console.log('graph-viewer-load-source.test.ts ok')

--- a/site/content/index.md
+++ b/site/content/index.md
@@ -218,12 +218,66 @@ Ask graph and trace questions in plain language. In the real viewer, answers are
   :runtime-a-i-chat-preview
 ::
 
+::u-page-section
+---
+class: dark:bg-neutral-950
+orientation: horizontal
+ui:
+  container: py-10 sm:py-12 lg:py-16 gap-8 sm:gap-10
+---
+#title
+::span{class="inline-flex items-center gap-3"}
+  :u-icon{name="i-lucide-play" class="size-9 shrink-0 text-primary"}
+  Run Providers From The Graph
+::
+
+#description
+Turn your runtime graph into an action surface. Select `Service` inside `Module`, choose a method, and execute the resolved provider without building a temporary endpoint.
+
+#features
+  :::u-page-feature
+  ---
+  icon: i-lucide-box
+  ---
+  #title
+  Provider-First Execution
+
+  #description
+  Run the provider NestJS already resolved in its module context.
+  :::
+
+  :::u-page-feature
+  ---
+  icon: i-lucide-file-json
+  ---
+  #title
+  JSON Arguments
+
+  #description
+  Pass method inputs from the graph and inspect the result in place.
+  :::
+
+  :::u-page-feature
+  ---
+  icon: i-lucide-zap
+  ---
+  #title
+  Faster Runtime Checks
+
+  #description
+  Validate service behavior without wiring a controller, route, or one-off script.
+  :::
+
+#default
+  :runtime-graph-direct-run-preview
+::
+
 ::u-page-section{class="dark:bg-neutral-950"}
 #title
 Next Feature List
 
 #description
-Better than now, just for you
+Better than now, make our service more stable
 
 #features
   :::u-page-feature
@@ -235,17 +289,6 @@ Better than now, just for you
 
   #description
   Coming soon: generate sequence diagrams from entry point to completion.
-  :::
-
-  :::u-page-feature
-  ---
-  icon: i-lucide-play
-  ---
-  #title
-  Direct Run :badge[Coming Soon]{.ml-2}
-
-  #description
-  Coming soon: execute runtime-resolved services directly from graph context.
   :::
 ::
 

--- a/site/package.json
+++ b/site/package.json
@@ -10,6 +10,7 @@
     "typecheck": "nuxt typecheck"
   },
   "dependencies": {
+    "@guolao/vue-monaco-editor": "^1.6.0",
     "@iconify-json/lucide": "^1.2.113",
     "@iconify-json/simple-icons": "^1.2.86",
     "@iconify-json/vscode-icons": "^1.2.58",
@@ -33,6 +34,7 @@
     "langchain": "^1.4.5",
     "mermaid": "^11.15.0",
     "minimark": "^0.2.0",
+    "monaco-editor": "^0.55.1",
     "nuxt": "^4.4.8",
     "nuxt-llms": "0.2.0",
     "nuxt-og-image": "^5.1.13",

--- a/site/public/mock-graph/output.json
+++ b/site/public/mock-graph/output.json
@@ -39,11 +39,47 @@
               },
               "token": "MobileService"
             }
-          ]
+          ],
+          "directRun": {
+            "methods": [
+              {
+                "name": "createUser",
+                "parameterTypes": "[{ name, email }: { name: string; email: string }]"
+              },
+              {
+                "name": "getAllUsers",
+                "parameterTypes": "[]"
+              },
+              {
+                "name": "getFeaturedMobileProductName",
+                "parameterTypes": "[productId: number]"
+              },
+              {
+                "name": "getUserById",
+                "parameterTypes": "[id: number]"
+              }
+            ]
+          }
         },
         {
           "name": "UserRepository",
-          "dependencies": []
+          "dependencies": [],
+          "directRun": {
+            "methods": [
+              {
+                "name": "create",
+                "parameterTypes": "[name: string, email: string]"
+              },
+              {
+                "name": "findAll",
+                "parameterTypes": "[]"
+              },
+              {
+                "name": "findById",
+                "parameterTypes": "[id: number]"
+              }
+            ]
+          }
         },
         {
           "name": "UserSchedule",
@@ -56,7 +92,15 @@
               },
               "token": "UserRepository"
             }
-          ]
+          ],
+          "directRun": {
+            "methods": [
+              {
+                "name": "reward",
+                "parameterTypes": "[]"
+              }
+            ]
+          }
         }
       ],
       "controllers": [
@@ -99,7 +143,15 @@
               },
               "token": "ProductService"
             }
-          ]
+          ],
+          "directRun": {
+            "methods": [
+              {
+                "name": "getFeaturedProductName",
+                "parameterTypes": "[productId: number]"
+              }
+            ]
+          }
         }
       ],
       "controllers": []
@@ -131,11 +183,55 @@
               },
               "token": "MobileService"
             }
-          ]
+          ],
+          "directRun": {
+            "methods": [
+              {
+                "name": "createProduct",
+                "parameterTypes": "[name: string, price: number, ownerId: number]"
+              },
+              {
+                "name": "getAllProducts",
+                "parameterTypes": "[]"
+              },
+              {
+                "name": "getMobileFeaturedProductName",
+                "parameterTypes": "[productId: number]"
+              },
+              {
+                "name": "getProductById",
+                "parameterTypes": "[id: number]"
+              },
+              {
+                "name": "getProductsByOwner",
+                "parameterTypes": "[ownerId: number]"
+              }
+            ]
+          }
         },
         {
           "name": "ProductRepository",
-          "dependencies": []
+          "dependencies": [],
+          "directRun": {
+            "methods": [
+              {
+                "name": "create",
+                "parameterTypes": "[name: string, price: number, ownerId: number]"
+              },
+              {
+                "name": "findAll",
+                "parameterTypes": "[]"
+              },
+              {
+                "name": "findById",
+                "parameterTypes": "[id: number]"
+              },
+              {
+                "name": "findByOwnerId",
+                "parameterTypes": "[ownerId: number]"
+              }
+            ]
+          }
         }
       ],
       "controllers": [
@@ -164,7 +260,31 @@
       "providers": [
         {
           "name": "OrderRepository",
-          "dependencies": []
+          "dependencies": [],
+          "directRun": {
+            "methods": [
+              {
+                "name": "create",
+                "parameterTypes": "[userId: number, productId: number, quantity: number]"
+              },
+              {
+                "name": "findAll",
+                "parameterTypes": "[]"
+              },
+              {
+                "name": "findById",
+                "parameterTypes": "[id: number]"
+              },
+              {
+                "name": "findByUserId",
+                "parameterTypes": "[userId: number]"
+              },
+              {
+                "name": "updateStatus",
+                "parameterTypes": "[id: number, status: \"pending\" | \"confirmed\" | \"shipped\"]"
+              }
+            ]
+          }
         },
         {
           "name": "OrderService",
@@ -197,7 +317,31 @@
               },
               "token": "OrderNotificationService"
             }
-          ]
+          ],
+          "directRun": {
+            "methods": [
+              {
+                "name": "confirmOrder",
+                "parameterTypes": "[id: number]"
+              },
+              {
+                "name": "createOrder",
+                "parameterTypes": "[userId: number, productId: number, quantity: number]"
+              },
+              {
+                "name": "getAllOrders",
+                "parameterTypes": "[]"
+              },
+              {
+                "name": "getOrderById",
+                "parameterTypes": "[id: number]"
+              },
+              {
+                "name": "getOrdersByUser",
+                "parameterTypes": "[userId: number]"
+              }
+            ]
+          }
         },
         {
           "name": "OrderNotificationService",
@@ -210,7 +354,19 @@
               },
               "token": "OrderService"
             }
-          ]
+          ],
+          "directRun": {
+            "methods": [
+              {
+                "name": "notifyOrderCreated",
+                "parameterTypes": "[order: { id: number; userId: number; productId: number; quantity: number; status: \"pending\" | \"confirmed\" | \"shipped\" }]"
+              },
+              {
+                "name": "notifyOrderShipped",
+                "parameterTypes": "[orderId: number]"
+              }
+            ]
+          }
         }
       ],
       "controllers": [


### PR DESCRIPTION
## Summary
- add direct-run output adapter and setup wiring in nest-graph-inspector
- add viewer-side direct-run provider flow for `/view/[url]`
- keep this PR stacked on `feat/graph-viewer-analytics-events` so analytics diff stays out

## Validation
- `corepack pnpm test -- --runInBand nest-graph-inspector.setup.spec.ts adapters/direct-run-output.adapter.spec.ts adapters/viewer-output.adapter.spec.ts nest-graph-inspector.module.spec.ts`
- `node app/utils/direct-run-provider.test.ts`
- `node app/utils/graph-viewer-load-source.test.ts`
- `eslint app/components/GraphViewer.vue app/utils/direct-run-provider.test.ts`

## Notes
- `corepack pnpm typecheck` still fails on pre-existing unrelated issue in `site/app/utils/graph-viewer-load-source.test.ts` importing `./graph-viewer-analytics.ts`
- `corepack pnpm lint` still reports pre-existing unrelated errors in `GraphInspectorUpdateModal.vue`, `graph-inspector.ts`, and `nuxt.config.ts`
