### PR TITLE
fix: correct issues viewer load source tracking

### DIFF
--- a/site/app/pages/view/[url]/issues.vue
+++ b/site/app/pages/view/[url]/issues.vue
@@ -17,8 +17,6 @@ const posthog = usePostHog()
 const graphStore = useGraphInspectorStore()
 const { decodedUrl, graphData, status, errorMessage } = storeToRefs(graphStore)
 
-let hasTrackedInitialMount = false
-
 const urlBase64 = computed(() => {
   const param = route.params.url
   return Array.isArray(param) ? param[0] : param
@@ -93,9 +91,8 @@ async function loadGraphResources(
   }
 }
 
-watch(encodedUrl, (value) => {
-  const loadSource = resolveGraphViewerLoadSource(hasTrackedInitialMount)
-  hasTrackedInitialMount = true
+watch(encodedUrl, (value, previousValue) => {
+  const loadSource = resolveGraphViewerLoadSource(Boolean(previousValue))
   loadGraphResources(value, loadSource)
 }, { immediate: true })
 


### PR DESCRIPTION
## Summary
- fixes the remaining analytics/load-source follow-up beyond old merged PR #17
- updates `site/app/pages/view/[url]/issues.vue` to use the current graph viewer load-source tracking flow
- removes the stale `hasTrackedInitialMount` path so initial load attribution stays aligned with the shared analytics logic

## Scope
This PR contains only the one clean analytics change that remained after PR #17 was merged to `main`.

## Verification
- `cd site/app/utils && node graph-viewer-load-source.test.ts`
- `cd site && corepack pnpm typecheck` *(currently fails on pre-existing unrelated `main` typing issues; this PR only changes `issues.vue`)*
