### PR TITLE
feat(lib): gate inspector endpoints behind a short-lived access token

### DIFF
--- a/demo/test/app.e2e-spec.ts
+++ b/demo/test/app.e2e-spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
 import request from 'supertest';
 import { App } from 'supertest/types';
+import { AccessTokenService } from 'nest-graph-inspector';
 import { AppModule } from './../src/app.module';
 
 describe('ProductController (e2e)', () => {
@@ -48,8 +49,13 @@ describe('ProductController (e2e)', () => {
       .expect(200)
       .expect('Featured product');
 
+    // The graph endpoint is token gated, and the token is held by the
+    // inspector running inside this application.
+    const accessToken = app.get(AccessTokenService, { strict: false });
+
     const graphResponse = await request('http://localhost:53371')
       .get('/__graph-inspector/output.json')
+      .set('Authorization', `Bearer ${accessToken.current()}`)
       .expect('content-type', /json/)
       .expect(200);
 

--- a/demo/test/graph-inspector-security.e2e-spec.ts
+++ b/demo/test/graph-inspector-security.e2e-spec.ts
@@ -1,0 +1,331 @@
+import http from 'node:http';
+import os from 'node:os';
+import { INestApplication, Injectable, Module } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import {
+  ACCESS_TOKEN_HEADER,
+  ACCESS_TOKEN_QUERY_PARAM,
+  AccessTokenService,
+  NestGraphInspectorModule,
+  NestGraphInspectorModuleOptions,
+} from 'nest-graph-inspector';
+
+/**
+ * Network-level checks for the inspector endpoints.
+ *
+ * These boot the real `NestGraphInspectorModule` and talk to it over TCP,
+ * rather than assembling adapters by hand, so a mistake in how the guard is
+ * wired into the module shows up here.
+ */
+
+/** Stands in for the kind of provider direct run can reach. */
+@Injectable()
+class VaultService {
+  readonly invocations: string[] = [];
+
+  readSecret(): string {
+    this.invocations.push('readSecret');
+
+    return 'production-database-password';
+  }
+}
+
+@Module({ providers: [VaultService], exports: [VaultService] })
+class VaultModule {}
+
+type Probe = {
+  statusCode: number;
+  headers: http.IncomingHttpHeaders;
+  body: string;
+};
+
+type ProbeOptions = {
+  method?: string;
+  headers?: http.OutgoingHttpHeaders;
+  body?: string;
+};
+
+function probe(url: string, options: ProbeOptions = {}): Promise<Probe> {
+  return new Promise((resolve, reject) => {
+    const request = http.request(
+      url,
+      { method: options.method ?? 'GET', headers: options.headers },
+      (response) => {
+        let body = '';
+
+        response.setEncoding('utf8');
+        response.on('data', (chunk: string) => {
+          body += chunk;
+        });
+        response.on('end', () =>
+          resolve({
+            statusCode: response.statusCode ?? 0,
+            headers: response.headers,
+            body,
+          }),
+        );
+      },
+    );
+
+    request.on('error', reject);
+    request.end(options.body);
+  });
+}
+
+function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = http.createServer();
+
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+
+      if (!address || typeof address === 'string') {
+        server.close(() => reject(new Error('Expected a TCP address')));
+        return;
+      }
+
+      const { port } = address;
+      server.close(() => resolve(port));
+    });
+  });
+}
+
+/** First non-loopback IPv4 address, used to reach the inspector off-loopback. */
+function externalIpv4(): string | undefined {
+  for (const addresses of Object.values(os.networkInterfaces())) {
+    for (const address of addresses ?? []) {
+      if (address.family === 'IPv4' && !address.internal) {
+        return address.address;
+      }
+    }
+  }
+
+  return undefined;
+}
+
+async function bootInspector(config: {
+  host: string;
+  port: number;
+  accessToken?: NestGraphInspectorModuleOptions['accessToken'];
+}): Promise<{ app: INestApplication; vault: VaultService; token: string }> {
+  const moduleRef = await Test.createTestingModule({
+    imports: [
+      VaultModule,
+      NestGraphInspectorModule.forRoot({
+        outputs: [{ type: 'viewer', host: config.host, port: config.port }],
+        ...(config.accessToken ? { accessToken: config.accessToken } : {}),
+      }),
+    ],
+  }).compile();
+
+  const app = moduleRef.createNestApplication();
+  await app.init();
+
+  return {
+    app,
+    vault: app.get(VaultService, { strict: false }),
+    token: app.get(AccessTokenService, { strict: false }).current(),
+  };
+}
+
+const DIRECT_RUN_BODY = JSON.stringify({
+  module: 'VaultModule',
+  provider: 'VaultService',
+  method: 'readSecret',
+});
+
+describe('Graph inspector network access', () => {
+  describe('an anonymous caller', () => {
+    let app: INestApplication;
+    let vault: VaultService;
+    let token: string;
+    let origin: string;
+
+    beforeAll(async () => {
+      const port = await freePort();
+      origin = `http://127.0.0.1:${port}`;
+      ({ app, vault, token } = await bootInspector({
+        host: '127.0.0.1',
+        port,
+      }));
+    });
+
+    afterAll(() => app.close());
+
+    it.each([
+      ['the endpoint metadata', 'GET', '/__graph-inspector/information.json'],
+      ['the dependency graph', 'GET', '/__graph-inspector/output.json'],
+      ['the graph schema', 'GET', '/__graph-inspector/output.schema.json'],
+      ['the markdown graph', 'GET', '/__graph-inspector/output.md'],
+      ['direct run', 'POST', '/direct-run'],
+      ['the direct run history', 'GET', '/direct-run/histories'],
+      ['the direct run history index', 'GET', '/direct-run/history/index.json'],
+      ['the Ollama proxy', 'GET', '/ollama/api/tags'],
+    ])('is refused %s', async (_label, method, path) => {
+      const response = await probe(`${origin}${path}`, { method });
+
+      expect(response.statusCode).toBe(401);
+    });
+
+    it('cannot invoke a provider method through direct run', async () => {
+      const response = await probe(`${origin}/direct-run`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: DIRECT_RUN_BODY,
+      });
+
+      expect(response.statusCode).toBe(401);
+      expect(response.body).not.toContain('production-database-password');
+      expect(vault.invocations).toEqual([]);
+    });
+
+    it('is served once it presents the token', async () => {
+      const response = await probe(`${origin}/__graph-inspector/output.json`, {
+        headers: { authorization: `Bearer ${token}` },
+      });
+
+      const graph = JSON.parse(response.body) as {
+        modules: Record<string, unknown>;
+      };
+
+      expect(response.statusCode).toBe(200);
+      expect(Object.keys(graph.modules)).toContain('VaultModule');
+    });
+
+    it.each([
+      [
+        'an Authorization bearer header',
+        () => ({ headers: { authorization: `Bearer ${token}` }, path: '' }),
+      ],
+      [
+        'the dedicated header',
+        () => ({ headers: { [ACCESS_TOKEN_HEADER]: token }, path: '' }),
+      ],
+      [
+        'the query parameter',
+        () => ({ headers: {}, path: `?${ACCESS_TOKEN_QUERY_PARAM}=${token}` }),
+      ],
+    ])('accepts the token from %s', async (_label, build) => {
+      const { headers, path } = build();
+      const response = await probe(
+        `${origin}/__graph-inspector/output.json${path}`,
+        { headers },
+      );
+
+      expect(response.statusCode).toBe(200);
+    });
+
+    it('runs the provider method once the token is presented', async () => {
+      const response = await probe(`${origin}/direct-run`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          authorization: `Bearer ${token}`,
+        },
+        body: DIRECT_RUN_BODY,
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(JSON.parse(response.body)).toMatchObject({
+        ok: true,
+        result: 'production-database-password',
+      });
+      expect(vault.invocations).toEqual(['readSecret']);
+    });
+  });
+
+  describe('a caller that keeps guessing', () => {
+    let app: INestApplication;
+    let token: string;
+    let origin: string;
+
+    beforeAll(async () => {
+      const port = await freePort();
+      origin = `http://127.0.0.1:${port}`;
+      ({ app, token } = await bootInspector({
+        host: '127.0.0.1',
+        port,
+        accessToken: { bruteForce: { maxFailures: 4, blockMs: 120_000 } },
+      }));
+    });
+
+    afterAll(() => app.close());
+
+    it('is locked out, token or not, once it runs out of attempts', async () => {
+      const guess = (attempt: number) =>
+        probe(`${origin}/__graph-inspector/output.json`, {
+          headers: { authorization: `Bearer ngi1.eyJhIjoxfQ.guess${attempt}` },
+        });
+
+      for (let attempt = 1; attempt <= 4; attempt += 1) {
+        expect((await guess(attempt)).statusCode).toBe(401);
+      }
+
+      const blocked = await guess(5);
+      expect(blocked.statusCode).toBe(429);
+      expect(Number(blocked.headers['retry-after'])).toBeGreaterThan(0);
+
+      // The lockout follows the caller, so a real token does not lift it.
+      const withRealToken = await probe(
+        `${origin}/__graph-inspector/output.json`,
+        { headers: { authorization: `Bearer ${token}` } },
+      );
+      expect(withRealToken.statusCode).toBe(429);
+    });
+  });
+
+  const lanAddress = externalIpv4();
+  const describeOffLoopback = lanAddress ? describe : describe.skip;
+
+  describeOffLoopback('a caller on another network interface', () => {
+    let app: INestApplication;
+    let token: string;
+    let lanOrigin: string;
+    let loopbackOrigin: string;
+
+    beforeAll(async () => {
+      const port = await freePort();
+      lanOrigin = `http://${lanAddress}:${port}`;
+      loopbackOrigin = `http://127.0.0.1:${port}`;
+      // The default binding, which is what makes the inspector reachable from
+      // outside the machine in the first place.
+      ({ app, token } = await bootInspector({
+        host: '0.0.0.0',
+        port,
+        accessToken: { bruteForce: { maxFailures: 2, blockMs: 120_000 } },
+      }));
+    });
+
+    afterAll(() => app.close());
+
+    it('reaches the inspector but is still refused without a token', async () => {
+      const response = await probe(
+        `${lanOrigin}/__graph-inspector/output.json`,
+      );
+
+      // A connection was accepted, so the port really is exposed; the 401 is
+      // what stands between the network and the graph.
+      expect(response.statusCode).toBe(401);
+      expect(JSON.parse(response.body)).toMatchObject({ reason: 'missing' });
+    });
+
+    it('does not lock out other callers when it is blocked', async () => {
+      const guess = (attempt: number) =>
+        probe(`${lanOrigin}/__graph-inspector/output.json`, {
+          headers: { authorization: `Bearer ngi1.eyJhIjoxfQ.guess${attempt}` },
+        });
+
+      expect((await guess(1)).statusCode).toBe(401);
+      expect((await guess(2)).statusCode).toBe(401);
+      expect((await guess(3)).statusCode).toBe(429);
+
+      const fromLoopback = await probe(
+        `${loopbackOrigin}/__graph-inspector/output.json`,
+        { headers: { authorization: `Bearer ${token}` } },
+      );
+
+      expect(fromLoopback.statusCode).toBe(200);
+    });
+  });
+});

--- a/demo/test/graph-inspector-security.e2e-spec.ts
+++ b/demo/test/graph-inspector-security.e2e-spec.ts
@@ -168,6 +168,21 @@ describe('Graph inspector network access', () => {
       expect(response.statusCode).toBe(401);
     });
 
+    it('can still complete a CORS preflight without a token', async () => {
+      // A preflight carries no credentials of its own, so guarding it would
+      // stop the browser from ever sending the request it asks about.
+      const response = await probe(`${origin}/direct-run`, {
+        method: 'OPTIONS',
+        headers: {
+          origin: 'https://albasyir.github.io',
+          'access-control-request-method': 'POST',
+        },
+      });
+
+      expect(response.statusCode).toBe(204);
+      expect(response.headers['access-control-allow-origin']).toBeDefined();
+    });
+
     it('cannot invoke a provider method through direct run', async () => {
       const response = await probe(`${origin}/direct-run`, {
         method: 'POST',

--- a/demo/test/graph-inspector-security.e2e-spec.ts
+++ b/demo/test/graph-inspector-security.e2e-spec.ts
@@ -3,8 +3,6 @@ import os from 'node:os';
 import { INestApplication, Injectable, Module } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
 import {
-  ACCESS_TOKEN_HEADER,
-  ACCESS_TOKEN_QUERY_PARAM,
   AccessTokenService,
   NestGraphInspectorModule,
   NestGraphInspectorModuleOptions,
@@ -206,29 +204,6 @@ describe('Graph inspector network access', () => {
 
       expect(response.statusCode).toBe(200);
       expect(Object.keys(graph.modules)).toContain('VaultModule');
-    });
-
-    it.each([
-      [
-        'an Authorization bearer header',
-        () => ({ headers: { authorization: `Bearer ${token}` }, path: '' }),
-      ],
-      [
-        'the dedicated header',
-        () => ({ headers: { [ACCESS_TOKEN_HEADER]: token }, path: '' }),
-      ],
-      [
-        'the query parameter',
-        () => ({ headers: {}, path: `?${ACCESS_TOKEN_QUERY_PARAM}=${token}` }),
-      ],
-    ])('accepts the token from %s', async (_label, build) => {
-      const { headers, path } = build();
-      const response = await probe(
-        `${origin}/__graph-inspector/output.json${path}`,
-        { headers },
-      );
-
-      expect(response.statusCode).toBe(200);
     });
 
     it('runs the provider method once the token is presented', async () => {

--- a/lib/src/access-attempt-limiter.spec.ts
+++ b/lib/src/access-attempt-limiter.spec.ts
@@ -67,6 +67,22 @@ describe(AccessAttemptLimiter.name, () => {
     expect(limiter.check('10.0.0.1')).toEqual({ blocked: false });
   });
 
+  it('keeps an active block when the failure window rolls over', () => {
+    at(1_000);
+    // blockMs outliving windowMs is the default shape, not an edge case.
+    const limiter = new AccessAttemptLimiter({
+      maxFailures: 1,
+      windowMs: 1_000,
+      blockMs: 60_000,
+    });
+    limiter.recordFailure('10.0.0.1');
+
+    at(2_500);
+    limiter.recordFailure('10.0.0.1');
+
+    expect(limiter.check('10.0.0.1')).toMatchObject({ blocked: true });
+  });
+
   it('forgets failures that fall outside the window', () => {
     at(1_000);
     const limiter = new AccessAttemptLimiter({

--- a/lib/src/access-attempt-limiter.spec.ts
+++ b/lib/src/access-attempt-limiter.spec.ts
@@ -1,0 +1,149 @@
+import {
+  AccessAttemptLimiter,
+  DEFAULT_BLOCK_MS,
+  DEFAULT_MAX_FAILURES,
+} from './access-attempt-limiter';
+
+describe(AccessAttemptLimiter.name, () => {
+  const at = (ms: number) => jest.spyOn(Date, 'now').mockReturnValue(ms);
+
+  afterEach(() => jest.restoreAllMocks());
+
+  it('allows a client that has never failed', () => {
+    expect(new AccessAttemptLimiter().check('10.0.0.1')).toEqual({
+      blocked: false,
+    });
+  });
+
+  it('allows failures up to the limit, then blocks', () => {
+    const limiter = new AccessAttemptLimiter({ maxFailures: 3 });
+
+    limiter.recordFailure('10.0.0.1');
+    limiter.recordFailure('10.0.0.1');
+    expect(limiter.check('10.0.0.1')).toEqual({ blocked: false });
+
+    limiter.recordFailure('10.0.0.1');
+    expect(limiter.check('10.0.0.1')).toMatchObject({ blocked: true });
+  });
+
+  it('reports how long a blocked client has to wait', () => {
+    at(1_000);
+    const limiter = new AccessAttemptLimiter({
+      maxFailures: 1,
+      blockMs: 60_000,
+    });
+    limiter.recordFailure('10.0.0.1');
+
+    at(21_000);
+    expect(limiter.check('10.0.0.1')).toEqual({
+      blocked: true,
+      retryAfterMs: 40_000,
+    });
+  });
+
+  it('blocks only the client that failed', () => {
+    const limiter = new AccessAttemptLimiter({ maxFailures: 1 });
+    limiter.recordFailure('10.0.0.1');
+
+    expect(limiter.check('10.0.0.1')).toMatchObject({ blocked: true });
+    expect(limiter.check('10.0.0.2')).toEqual({ blocked: false });
+  });
+
+  it('lets a client back in with a full allowance once the block expires', () => {
+    at(1_000);
+    const limiter = new AccessAttemptLimiter({
+      maxFailures: 2,
+      blockMs: 10_000,
+    });
+    limiter.recordFailure('10.0.0.1');
+    limiter.recordFailure('10.0.0.1');
+    expect(limiter.check('10.0.0.1')).toMatchObject({ blocked: true });
+
+    at(11_001);
+    expect(limiter.check('10.0.0.1')).toEqual({ blocked: false });
+
+    // One failure must not put the client straight back into a block.
+    limiter.recordFailure('10.0.0.1');
+    expect(limiter.check('10.0.0.1')).toEqual({ blocked: false });
+  });
+
+  it('forgets failures that fall outside the window', () => {
+    at(1_000);
+    const limiter = new AccessAttemptLimiter({
+      maxFailures: 2,
+      windowMs: 5_000,
+    });
+    limiter.recordFailure('10.0.0.1');
+
+    at(7_000);
+    limiter.recordFailure('10.0.0.1');
+
+    expect(limiter.check('10.0.0.1')).toEqual({ blocked: false });
+  });
+
+  it('clears a client history once it presents a valid token', () => {
+    const limiter = new AccessAttemptLimiter({ maxFailures: 2 });
+    limiter.recordFailure('10.0.0.1');
+    limiter.recordSuccess('10.0.0.1');
+    limiter.recordFailure('10.0.0.1');
+
+    expect(limiter.check('10.0.0.1')).toEqual({ blocked: false });
+    expect(limiter.size()).toBe(1);
+  });
+
+  it('keeps the tracked client count bounded', () => {
+    const limiter = new AccessAttemptLimiter({ maxTrackedClients: 25 });
+
+    for (let index = 0; index < 500; index += 1) {
+      limiter.recordFailure(`10.0.${Math.floor(index / 256)}.${index % 256}`);
+    }
+
+    expect(limiter.size()).toBeLessThanOrEqual(25);
+  });
+
+  it('does not let traffic from other addresses flush an active block', () => {
+    at(1_000);
+    const limiter = new AccessAttemptLimiter({
+      maxFailures: 2,
+      maxTrackedClients: 5,
+      windowMs: 600_000,
+      blockMs: 600_000,
+    });
+    limiter.recordFailure('10.0.0.1');
+    limiter.recordFailure('10.0.0.1');
+    expect(limiter.check('10.0.0.1')).toMatchObject({ blocked: true });
+
+    // Well past the cap, but none of these reach the block threshold, so the
+    // tracker has plenty of unblocked records to give up first.
+    for (let index = 0; index < 50; index += 1) {
+      at(1_000 + index);
+      limiter.recordFailure(`10.9.0.${index}`);
+    }
+
+    at(2_000);
+    expect(limiter.check('10.0.0.1')).toMatchObject({ blocked: true });
+    expect(limiter.size()).toBeLessThanOrEqual(5);
+  });
+
+  it('counts nothing when the limiter is turned off', () => {
+    const limiter = new AccessAttemptLimiter({
+      enabled: false,
+      maxFailures: 1,
+    });
+    limiter.recordFailure('10.0.0.1');
+    limiter.recordFailure('10.0.0.1');
+
+    expect(limiter.isEnabled()).toBe(false);
+    expect(limiter.check('10.0.0.1')).toEqual({ blocked: false });
+  });
+
+  it('falls back to defaults for unusable settings', () => {
+    const limiter = new AccessAttemptLimiter({
+      maxFailures: 0,
+      blockMs: Number.NaN,
+    });
+
+    expect(limiter.maxFailures).toBe(DEFAULT_MAX_FAILURES);
+    expect(limiter.blockMs).toBe(DEFAULT_BLOCK_MS);
+  });
+});

--- a/lib/src/access-attempt-limiter.ts
+++ b/lib/src/access-attempt-limiter.ts
@@ -1,0 +1,201 @@
+export type AccessAttemptLimiterOptions = {
+  /** Whether failed token guesses are counted at all. Defaults to `true`. */
+  enabled?: boolean;
+  /** Guesses tolerated inside one window before the client is blocked. */
+  maxFailures?: number;
+  /** How long failures accumulate before the count resets. */
+  windowMs?: number;
+  /** How long a blocked client stays blocked. */
+  blockMs?: number;
+  /** Upper bound on tracked clients, so the tracker cannot be grown forever. */
+  maxTrackedClients?: number;
+};
+
+export const DEFAULT_MAX_FAILURES = 10;
+export const DEFAULT_FAILURE_WINDOW_MS = 60_000;
+export const DEFAULT_BLOCK_MS = 15 * 60_000;
+export const DEFAULT_MAX_TRACKED_CLIENTS = 1_000;
+
+export type AccessAttemptDecision =
+  | { blocked: false }
+  | { blocked: true; retryAfterMs: number };
+
+type ClientRecord = {
+  failures: number;
+  windowStartedAt: number;
+  lastSeenAt: number;
+  blockedUntil?: number;
+};
+
+/**
+ * Per-client lockout for failed access token guesses.
+ *
+ * Tokens are signed, so guessing one is already infeasible; this caps how fast
+ * an attacker may try at all, and makes the attempt visible as a block rather
+ * than an endless stream of 401s.
+ *
+ * The tracker is bounded on purpose: an unbounded map keyed by client address
+ * would itself be a way to exhaust the host's memory.
+ */
+export class AccessAttemptLimiter {
+  private readonly enabled: boolean;
+  readonly maxFailures: number;
+  readonly windowMs: number;
+  readonly blockMs: number;
+  private readonly maxTrackedClients: number;
+  private readonly clients = new Map<string, ClientRecord>();
+
+  constructor(options: AccessAttemptLimiterOptions = {}) {
+    this.enabled = options.enabled ?? true;
+    this.maxFailures = this.positive(options.maxFailures, DEFAULT_MAX_FAILURES);
+    this.windowMs = this.positive(options.windowMs, DEFAULT_FAILURE_WINDOW_MS);
+    this.blockMs = this.positive(options.blockMs, DEFAULT_BLOCK_MS);
+    this.maxTrackedClients = this.positive(
+      options.maxTrackedClients,
+      DEFAULT_MAX_TRACKED_CLIENTS,
+    );
+  }
+
+  isEnabled(): boolean {
+    return this.enabled;
+  }
+
+  /** Whether this client is currently locked out. */
+  check(clientId: string): AccessAttemptDecision {
+    if (!this.enabled) {
+      return { blocked: false };
+    }
+
+    const record = this.clients.get(clientId);
+    if (!record?.blockedUntil) {
+      return { blocked: false };
+    }
+
+    const now = Date.now();
+    if (now < record.blockedUntil) {
+      return { blocked: true, retryAfterMs: record.blockedUntil - now };
+    }
+
+    // The block has run its course, so the client starts over with a full
+    // allowance rather than one guess away from being blocked again.
+    this.clients.delete(clientId);
+
+    return { blocked: false };
+  }
+
+  /** Counts one failed guess, blocking the client once it runs out of them. */
+  recordFailure(clientId: string): void {
+    if (!this.enabled) {
+      return;
+    }
+
+    const now = Date.now();
+    const existing = this.clients.get(clientId);
+    const withinWindow =
+      existing !== undefined && now - existing.windowStartedAt < this.windowMs;
+
+    // A fresh window starts the count over, but still runs the threshold check
+    // below: with a limit of one, the very first guess has to block.
+    const record: ClientRecord = withinWindow
+      ? existing
+      : { failures: 0, windowStartedAt: now, lastSeenAt: now };
+
+    record.failures += 1;
+    record.lastSeenAt = now;
+
+    if (record.failures >= this.maxFailures) {
+      record.blockedUntil = now + this.blockMs;
+    }
+
+    if (!withinWindow) {
+      this.clients.set(clientId, record);
+
+      if (this.clients.size > this.maxTrackedClients) {
+        this.evict(now);
+      }
+    }
+  }
+
+  /** Clears a client's history once it proves it holds a valid token. */
+  recordSuccess(clientId: string): void {
+    this.clients.delete(clientId);
+  }
+
+  /** Tracked client count, for tests and diagnostics. */
+  size(): number {
+    return this.clients.size;
+  }
+
+  private evict(now: number): void {
+    for (const [clientId, record] of this.clients) {
+      if (
+        !this.isBlockedAt(record, now) &&
+        now - record.windowStartedAt >= this.windowMs
+      ) {
+        this.clients.delete(clientId);
+      }
+    }
+
+    while (this.clients.size > this.maxTrackedClients) {
+      const victim = this.evictionCandidate(now);
+
+      if (victim === undefined) {
+        return;
+      }
+
+      this.clients.delete(victim);
+    }
+  }
+
+  /**
+   * Picks what to drop when the tracker is full.
+   *
+   * Blocked clients are given up last, and the one whose block ends soonest
+   * goes first. Otherwise a client could flush its own block simply by filling
+   * the tracker with traffic from other addresses.
+   *
+   * If every tracked client is blocked, one block does end early. That is the
+   * price of a bounded tracker, and it costs the attacker far more traffic
+   * than evicting an idle record would.
+   */
+  private evictionCandidate(now: number): string | undefined {
+    let candidate: string | undefined;
+    let candidateRank = Number.POSITIVE_INFINITY;
+    let candidateIsBlocked = true;
+
+    for (const [clientId, record] of this.clients) {
+      const blocked = this.isBlockedAt(record, now);
+
+      if (candidateIsBlocked && !blocked) {
+        candidate = clientId;
+        candidateRank = record.lastSeenAt;
+        candidateIsBlocked = false;
+        continue;
+      }
+
+      if (blocked !== candidateIsBlocked) {
+        continue;
+      }
+
+      const rank = blocked ? (record.blockedUntil ?? 0) : record.lastSeenAt;
+      if (rank < candidateRank) {
+        candidate = clientId;
+        candidateRank = rank;
+      }
+    }
+
+    return candidate;
+  }
+
+  private isBlockedAt(record: ClientRecord, now: number): boolean {
+    return record.blockedUntil !== undefined && now < record.blockedUntil;
+  }
+
+  private positive(value: number | undefined, fallback: number): number {
+    if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+      return fallback;
+    }
+
+    return Math.floor(value);
+  }
+}

--- a/lib/src/access-attempt-limiter.ts
+++ b/lib/src/access-attempt-limiter.ts
@@ -95,10 +95,17 @@ export class AccessAttemptLimiter {
       existing !== undefined && now - existing.windowStartedAt < this.windowMs;
 
     // A fresh window starts the count over, but still runs the threshold check
-    // below: with a limit of one, the very first guess has to block.
+    // below: with a limit of one, the very first guess has to block. An active
+    // block carries over, since blockMs outlives windowMs by default and
+    // rolling the window must not hand a blocked client a clean slate.
     const record: ClientRecord = withinWindow
       ? existing
-      : { failures: 0, windowStartedAt: now, lastSeenAt: now };
+      : {
+          failures: 0,
+          windowStartedAt: now,
+          lastSeenAt: now,
+          blockedUntil: existing?.blockedUntil,
+        };
 
     record.failures += 1;
     record.lastSeenAt = now;

--- a/lib/src/access-token.service.spec.ts
+++ b/lib/src/access-token.service.spec.ts
@@ -1,0 +1,230 @@
+import http from 'node:http';
+import {
+  ACCESS_TOKEN_HEADER,
+  ACCESS_TOKEN_QUERY_PARAM,
+  AccessTokenService,
+  DEFAULT_ACCESS_TOKEN_TTL_MS,
+} from './access-token.service';
+
+/** Minimal stand-in for an inbound request the guard inspects. */
+function request(options: {
+  url?: string;
+  headers?: http.IncomingHttpHeaders;
+}): http.IncomingMessage {
+  return {
+    url: options.url ?? '/__graph-inspector/output.json',
+    headers: options.headers ?? {},
+  } as http.IncomingMessage;
+}
+
+describe(AccessTokenService.name, () => {
+  // Several cases drive the clock forward; leaving it frozen would silently
+  // change what later cases mean.
+  afterEach(() => jest.restoreAllMocks());
+
+  it('issues a token that verifies against the issuing service', () => {
+    const service = new AccessTokenService();
+
+    expect(service.verify(service.current())).toMatchObject({ ok: true });
+  });
+
+  it('reuses the same token until it expires', () => {
+    const service = new AccessTokenService();
+
+    expect(service.current()).toBe(service.current());
+  });
+
+  it('expires a token once its lifetime has passed', () => {
+    const issuedAt = Date.parse('2026-08-15T13:00:00.000Z');
+    jest.spyOn(Date, 'now').mockReturnValue(issuedAt);
+
+    const service = new AccessTokenService({
+      accessToken: { ttlMs: 3 * 60 * 60 * 1000 },
+    });
+    const token = service.current();
+
+    jest.spyOn(Date, 'now').mockReturnValue(Date.parse('2026-08-15T15:59:59.000Z'));
+    expect(service.verify(token)).toMatchObject({ ok: true });
+
+    jest.spyOn(Date, 'now').mockReturnValue(Date.parse('2026-08-15T16:00:00.000Z'));
+    expect(service.verify(token)).toEqual({ ok: false, reason: 'expired' });
+  });
+
+  it('mints a replacement once the previous token has expired', () => {
+    jest.spyOn(Date, 'now').mockReturnValue(1_000);
+    const service = new AccessTokenService({ accessToken: { ttlMs: 100 } });
+    const first = service.current();
+
+    jest.spyOn(Date, 'now').mockReturnValue(2_000);
+    const second = service.current();
+
+    expect(second).not.toBe(first);
+    expect(service.verify(second)).toMatchObject({ ok: true });
+    expect(service.verify(first)).toEqual({ ok: false, reason: 'expired' });
+  });
+
+  it('rejects a token issued by a service with a different secret', () => {
+    const service = new AccessTokenService({
+      accessToken: { secret: 'first-application' },
+    });
+    const other = new AccessTokenService({
+      accessToken: { secret: 'second-application' },
+    });
+
+    expect(service.verify(other.current())).toEqual({
+      ok: false,
+      reason: 'signature',
+    });
+  });
+
+  it('rejects a token whose payload was edited to extend its expiry', () => {
+    const service = new AccessTokenService({ accessToken: { ttlMs: 1_000 } });
+    const [prefix, payload, signature] = service.current().split('.');
+    const forged = JSON.parse(
+      Buffer.from(payload, 'base64url').toString('utf8'),
+    );
+    forged.exp = Date.now() + 10 * 60 * 60 * 1000;
+
+    const tampered = [
+      prefix,
+      Buffer.from(JSON.stringify(forged)).toString('base64url'),
+      signature,
+    ].join('.');
+
+    expect(service.verify(tampered)).toEqual({
+      ok: false,
+      reason: 'signature',
+    });
+  });
+
+  it.each([
+    ['an empty token', ''],
+    ['a token with no signature', 'ngi1.eyJpYXQiOjEsImV4cCI6Mn0'],
+    ['a token with an unknown prefix', 'other.payload.signature'],
+  ])('rejects %s', (_label, token) => {
+    const service = new AccessTokenService();
+    const result = service.verify(token);
+
+    expect(result.ok).toBe(false);
+  });
+
+  it('keeps tokens valid across services that share a configured secret', () => {
+    const secret = 'shared-across-restarts';
+    const before = new AccessTokenService({ accessToken: { secret } });
+    const afterRestart = new AccessTokenService({ accessToken: { secret } });
+
+    expect(afterRestart.verify(before.current())).toMatchObject({ ok: true });
+  });
+
+  it('falls back to the default lifetime for an unusable ttl', () => {
+    for (const ttlMs of [0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
+      expect(new AccessTokenService({ accessToken: { ttlMs } }).ttlMs).toBe(
+        DEFAULT_ACCESS_TOKEN_TTL_MS,
+      );
+    }
+  });
+
+  describe('request authorization', () => {
+    let service: AccessTokenService;
+
+    beforeEach(() => {
+      service = new AccessTokenService({
+        accessToken: { secret: 'authorization-tests' },
+      });
+    });
+
+    it('reads the token from an Authorization bearer header', () => {
+      const result = service.authorizeRequest(
+        request({ headers: { authorization: `Bearer ${service.current()}` } }),
+      );
+
+      expect(result.ok).toBe(true);
+    });
+
+    it('reads the token from the dedicated header', () => {
+      const result = service.authorizeRequest(
+        request({ headers: { [ACCESS_TOKEN_HEADER]: service.current() } }),
+      );
+
+      expect(result.ok).toBe(true);
+    });
+
+    it('reads the token from the query parameter', () => {
+      const result = service.authorizeRequest(
+        request({
+          url: `/__graph-inspector/output.json?${ACCESS_TOKEN_QUERY_PARAM}=${service.current()}`,
+        }),
+      );
+
+      expect(result.ok).toBe(true);
+    });
+
+    it('reports a missing token when the request carries none', () => {
+      expect(service.authorizeRequest(request({}))).toEqual({
+        ok: false,
+        reason: 'missing',
+      });
+    });
+
+    it('authorizes every request when token protection is turned off', () => {
+      const disabled = new AccessTokenService({
+        accessToken: { enabled: false },
+      });
+
+      expect(disabled.authorizeRequest(request({}))).toEqual({ ok: true });
+    });
+  });
+
+  describe('http guard', () => {
+    it('answers 401 with the reason when a token is missing', () => {
+      const guard = new AccessTokenService().createHttpGuard();
+      const result = guard(request({}));
+
+      expect(result).toMatchObject({
+        ok: false,
+        response: {
+          statusCode: 401,
+          headers: {
+            'www-authenticate': 'Bearer realm="nest-graph-inspector"',
+          },
+          body: { ok: false, reason: 'missing' },
+        },
+      });
+    });
+
+    it('lets a valid token through', () => {
+      const service = new AccessTokenService();
+      const guard = service.createHttpGuard();
+
+      expect(
+        guard(
+          request({ headers: { authorization: `Bearer ${service.current()}` } }),
+        ),
+      ).toEqual({ ok: true });
+    });
+  });
+
+  describe('viewer link', () => {
+    it('appends the token to the graph endpoint url', () => {
+      const service = new AccessTokenService();
+      const url = service.appendToUrl(
+        new URL('http://127.0.0.1:53371/__graph-inspector'),
+      );
+
+      expect(
+        service.verify(url.searchParams.get(ACCESS_TOKEN_QUERY_PARAM)!),
+      ).toMatchObject({ ok: true });
+    });
+
+    it('leaves the url untouched when token protection is turned off', () => {
+      const service = new AccessTokenService({
+        accessToken: { enabled: false },
+      });
+      const url = service.appendToUrl(
+        new URL('http://127.0.0.1:53371/__graph-inspector'),
+      );
+
+      expect(url.toString()).toBe('http://127.0.0.1:53371/__graph-inspector');
+    });
+  });
+});

--- a/lib/src/access-token.service.spec.ts
+++ b/lib/src/access-token.service.spec.ts
@@ -192,6 +192,49 @@ describe(AccessTokenService.name, () => {
       });
     });
 
+    it('answers 429 with retry-after once the caller is locked out', () => {
+      jest.spyOn(Date, 'now').mockReturnValue(1_000);
+      const service = new AccessTokenService({
+        accessToken: { bruteForce: { maxFailures: 1, blockMs: 30_000 } },
+      });
+      const guard = service.createHttpGuard();
+      const guessing = request({
+        headers: { authorization: 'Bearer ngi1.eyJhIjoxfQ.wrong' },
+      });
+
+      // The first guess is refused and is what trips the lockout.
+      expect(guard(guessing)).toMatchObject({
+        ok: false,
+        response: { statusCode: 401, body: { reason: 'signature' } },
+      });
+
+      expect(guard(guessing)).toMatchObject({
+        ok: false,
+        response: {
+          statusCode: 429,
+          headers: { 'retry-after': '30' },
+          body: { reason: 'blocked' },
+        },
+      });
+    });
+
+    it('rounds a partial second of remaining block time up', () => {
+      jest.spyOn(Date, 'now').mockReturnValue(1_000);
+      const service = new AccessTokenService({
+        accessToken: { bruteForce: { maxFailures: 1, blockMs: 30_000 } },
+      });
+      const guard = service.createHttpGuard();
+      const guessing = request({
+        headers: { authorization: 'Bearer ngi1.eyJhIjoxfQ.wrong' },
+      });
+      guard(guessing);
+
+      jest.spyOn(Date, 'now').mockReturnValue(29_500);
+      expect(guard(guessing)).toMatchObject({
+        response: { headers: { 'retry-after': '2' } },
+      });
+    });
+
     it('lets a valid token through', () => {
       const service = new AccessTokenService();
       const guard = service.createHttpGuard();

--- a/lib/src/access-token.service.spec.ts
+++ b/lib/src/access-token.service.spec.ts
@@ -6,16 +6,25 @@ import {
   DEFAULT_ACCESS_TOKEN_TTL_MS,
 } from './access-token.service';
 
-/** Minimal stand-in for an inbound request the guard inspects. */
+/**
+ * Minimal stand-in for an inbound request the guard inspects.
+ *
+ * The socket address matters: it is how the guard tells callers apart, so
+ * omitting it would put every case in one lockout bucket.
+ */
 function request(options: {
   url?: string;
   headers?: http.IncomingHttpHeaders;
+  remoteAddress?: string;
 }): http.IncomingMessage {
   return {
     url: options.url ?? '/__graph-inspector/output.json',
     headers: options.headers ?? {},
+    socket: { remoteAddress: options.remoteAddress ?? '10.0.0.1' },
   } as http.IncomingMessage;
 }
+
+const WRONG_TOKEN = { authorization: 'Bearer ngi1.eyJhIjoxfQ.wrong' };
 
 describe(AccessTokenService.name, () => {
   // Several cases drive the clock forward; leaving it frozen would silently
@@ -26,12 +35,6 @@ describe(AccessTokenService.name, () => {
     const service = new AccessTokenService();
 
     expect(service.verify(service.current())).toMatchObject({ ok: true });
-  });
-
-  it('reuses the same token until it expires', () => {
-    const service = new AccessTokenService();
-
-    expect(service.current()).toBe(service.current());
   });
 
   it('expires a token once its lifetime has passed', () => {
@@ -54,6 +57,9 @@ describe(AccessTokenService.name, () => {
     jest.spyOn(Date, 'now').mockReturnValue(1_000);
     const service = new AccessTokenService({ accessToken: { ttlMs: 100 } });
     const first = service.current();
+
+    // Stable while it is still valid.
+    expect(service.current()).toBe(first);
 
     jest.spyOn(Date, 'now').mockReturnValue(2_000);
     const second = service.current();
@@ -133,27 +139,24 @@ describe(AccessTokenService.name, () => {
       });
     });
 
-    it('reads the token from an Authorization bearer header', () => {
-      const result = service.authorizeRequest(
-        request({ headers: { authorization: `Bearer ${service.current()}` } }),
-      );
-
-      expect(result.ok).toBe(true);
-    });
-
-    it('reads the token from the dedicated header', () => {
-      const result = service.authorizeRequest(
-        request({ headers: { [ACCESS_TOKEN_HEADER]: service.current() } }),
-      );
-
-      expect(result.ok).toBe(true);
-    });
-
-    it('reads the token from the query parameter', () => {
-      const result = service.authorizeRequest(
-        request({
-          url: `/__graph-inspector/output.json?${ACCESS_TOKEN_QUERY_PARAM}=${service.current()}`,
+    it.each([
+      [
+        'an Authorization bearer header',
+        (token: string) => ({ headers: { authorization: `Bearer ${token}` } }),
+      ],
+      [
+        'the dedicated header',
+        (token: string) => ({ headers: { [ACCESS_TOKEN_HEADER]: token } }),
+      ],
+      [
+        'the query parameter',
+        (token: string) => ({
+          url: `/__graph-inspector/output.json?${ACCESS_TOKEN_QUERY_PARAM}=${token}`,
         }),
+      ],
+    ])('reads the token from %s', (_label, build) => {
+      const result = service.authorizeRequest(
+        request(build(service.current())),
       );
 
       expect(result.ok).toBe(true);
@@ -198,9 +201,7 @@ describe(AccessTokenService.name, () => {
         accessToken: { bruteForce: { maxFailures: 1, blockMs: 30_000 } },
       });
       const guard = service.createHttpGuard();
-      const guessing = request({
-        headers: { authorization: 'Bearer ngi1.eyJhIjoxfQ.wrong' },
-      });
+      const guessing = request({ headers: WRONG_TOKEN });
 
       // The first guess is refused and is what trips the lockout.
       expect(guard(guessing)).toMatchObject({
@@ -216,23 +217,43 @@ describe(AccessTokenService.name, () => {
           body: { reason: 'blocked' },
         },
       });
-    });
 
-    it('rounds a partial second of remaining block time up', () => {
-      jest.spyOn(Date, 'now').mockReturnValue(1_000);
-      const service = new AccessTokenService({
-        accessToken: { bruteForce: { maxFailures: 1, blockMs: 30_000 } },
-      });
-      const guard = service.createHttpGuard();
-      const guessing = request({
-        headers: { authorization: 'Bearer ngi1.eyJhIjoxfQ.wrong' },
-      });
-      guard(guessing);
-
+      // Remaining block time rounds up rather than reporting zero seconds.
       jest.spyOn(Date, 'now').mockReturnValue(29_500);
       expect(guard(guessing)).toMatchObject({
         response: { headers: { 'retry-after': '2' } },
       });
+    });
+
+    it('locks out one caller without affecting another', () => {
+      const service = new AccessTokenService({
+        accessToken: { bruteForce: { maxFailures: 1, blockMs: 30_000 } },
+      });
+      const guard = service.createHttpGuard();
+
+      guard(request({ headers: WRONG_TOKEN, remoteAddress: '10.0.0.1' }));
+
+      expect(
+        guard(request({ headers: WRONG_TOKEN, remoteAddress: '10.0.0.1' })),
+      ).toMatchObject({ response: { statusCode: 429 } });
+      expect(
+        guard(request({ headers: WRONG_TOKEN, remoteAddress: '10.0.0.2' })),
+      ).toMatchObject({ response: { statusCode: 401 } });
+    });
+
+    it('treats an IPv4-mapped address as the same caller', () => {
+      const service = new AccessTokenService({
+        accessToken: { bruteForce: { maxFailures: 1, blockMs: 30_000 } },
+      });
+      const guard = service.createHttpGuard();
+
+      guard(
+        request({ headers: WRONG_TOKEN, remoteAddress: '::ffff:10.0.0.1' }),
+      );
+
+      expect(
+        guard(request({ headers: WRONG_TOKEN, remoteAddress: '10.0.0.1' })),
+      ).toMatchObject({ response: { statusCode: 429 } });
     });
 
     it('lets a valid token through', () => {

--- a/lib/src/access-token.service.ts
+++ b/lib/src/access-token.service.ts
@@ -1,9 +1,10 @@
 import type http from 'node:http';
 import { createHmac, randomBytes, timingSafeEqual } from 'node:crypto';
-import { Inject, Injectable, Optional } from '@nestjs/common';
+import { Inject, Injectable, Logger, Optional } from '@nestjs/common';
 import { MODULE_OPTIONS_TOKEN } from './nest-graph-inspector.config';
 import type { NestGraphInspectorModuleOptions } from './nest-graph-inspector.type';
 import type { HttpServeAuthorize } from './adapters/http-serve.adapter';
+import { AccessAttemptLimiter } from './access-attempt-limiter';
 
 /**
  * Query parameter carrying the access token.
@@ -21,6 +22,21 @@ export const DEFAULT_ACCESS_TOKEN_TTL_MS = 3 * 60 * 60 * 1000;
 
 const TOKEN_PREFIX = 'ngi1';
 const SECRET_ENV_KEY = 'NEST_GRAPH_INSPECTOR_TOKEN_SECRET';
+
+/**
+ * Below this, a configured secret is worth brute forcing offline: a token's
+ * payload and signature are both readable, so anyone holding one leaked token
+ * can test candidate secrets locally, without touching the application.
+ */
+const MIN_SAFE_SECRET_LENGTH = 32;
+
+/**
+ * Rejections that mean a token was actually presented and did not check out.
+ *
+ * A missing token is not a guess, and an expired one can only be produced by
+ * something that already held a real token, so neither counts toward a lockout.
+ */
+const GUESS_REJECTIONS: ReadonlySet<string> = new Set(['malformed', 'signature']);
 
 export type AccessTokenPayload = {
   /** Issued at, epoch milliseconds. */
@@ -61,9 +77,11 @@ const REJECTION_MESSAGES: Record<AccessTokenRejection, string> = {
  */
 @Injectable()
 export class AccessTokenService {
+  private readonly logger = new Logger(AccessTokenService.name);
   private readonly enabled: boolean;
   private readonly secret: Buffer;
   readonly ttlMs: number;
+  readonly limiter: AccessAttemptLimiter;
   private issued: { token: string; payload: AccessTokenPayload } | undefined;
 
   constructor(
@@ -76,6 +94,7 @@ export class AccessTokenService {
     this.enabled = accessToken?.enabled ?? true;
     this.ttlMs = this.normalizeTtlMs(accessToken?.ttlMs);
     this.secret = this.resolveSecret(accessToken?.secret);
+    this.limiter = new AccessAttemptLimiter(accessToken?.bruteForce);
   }
 
   isEnabled(): boolean {
@@ -171,9 +190,30 @@ export class AccessTokenService {
    */
   createHttpGuard(): HttpServeAuthorize {
     return (req) => {
+      if (!this.enabled) {
+        return { ok: true };
+      }
+
+      const clientId = this.clientId(req);
+      const decision = this.limiter.check(clientId);
+      if (decision.blocked) {
+        return this.blockedResponse(decision.retryAfterMs);
+      }
+
       const result = this.authorizeRequest(req);
       if (result.ok) {
+        this.limiter.recordSuccess(clientId);
         return { ok: true };
+      }
+
+      if (GUESS_REJECTIONS.has(result.reason)) {
+        this.limiter.recordFailure(clientId);
+
+        if (this.limiter.check(clientId).blocked) {
+          this.logger.warn(
+            `Blocked ${clientId} from the graph inspector after ${this.limiter.maxFailures} invalid access tokens.`,
+          );
+        }
       }
 
       return {
@@ -192,6 +232,40 @@ export class AccessTokenService {
         },
       };
     };
+  }
+
+  private blockedResponse(retryAfterMs: number): ReturnType<HttpServeAuthorize> {
+    const retryAfterSeconds = Math.ceil(retryAfterMs / 1_000);
+
+    return {
+      ok: false,
+      response: {
+        statusCode: 429,
+        contentType: 'application/json; charset=utf-8',
+        headers: { 'retry-after': String(retryAfterSeconds) },
+        body: {
+          ok: false,
+          reason: 'blocked',
+          error: `Too many invalid graph inspector access tokens. Try again in ${retryAfterSeconds} seconds.`,
+        },
+      },
+    };
+  }
+
+  /**
+   * Identifies the client for lockout purposes.
+   *
+   * Deliberately the socket address rather than a forwarded header: a header
+   * is attacker-controlled, so trusting one would let a brute force rotate
+   * past the lockout, and would let anyone lock out an address they choose.
+   */
+  private clientId(req: http.IncomingMessage): string {
+    const address = req.socket?.remoteAddress ?? 'unknown';
+
+    // Node reports IPv4 peers on a dual-stack socket as ::ffff:127.0.0.1.
+    return address.startsWith('::ffff:')
+      ? address.slice('::ffff:'.length)
+      : address;
   }
 
   /** Appends the current token to a URL the viewer will load. */
@@ -287,7 +361,19 @@ export class AccessTokenService {
     // viewer. Without one, every process gets its own throwaway secret.
     const secret = configuredSecret ?? process.env[SECRET_ENV_KEY];
 
-    return secret ? Buffer.from(secret, 'utf8') : randomBytes(32);
+    if (!secret) {
+      return randomBytes(32);
+    }
+
+    if (this.enabled && secret.length < MIN_SAFE_SECRET_LENGTH) {
+      this.logger.warn(
+        `Graph inspector access token secret is ${secret.length} characters. ` +
+          `Use at least ${MIN_SAFE_SECRET_LENGTH}, or leave it unset for a random one: ` +
+          'a short secret can be recovered offline from a single leaked token.',
+      );
+    }
+
+    return Buffer.from(secret, 'utf8');
   }
 
   private normalizeTtlMs(ttlMs: number | undefined): number {

--- a/lib/src/access-token.service.ts
+++ b/lib/src/access-token.service.ts
@@ -1,0 +1,304 @@
+import type http from 'node:http';
+import { createHmac, randomBytes, timingSafeEqual } from 'node:crypto';
+import { Inject, Injectable, Optional } from '@nestjs/common';
+import { MODULE_OPTIONS_TOKEN } from './nest-graph-inspector.config';
+import type { NestGraphInspectorModuleOptions } from './nest-graph-inspector.type';
+import type { HttpServeAuthorize } from './adapters/http-serve.adapter';
+
+/**
+ * Query parameter carrying the access token.
+ *
+ * The hosted viewer loads graph data straight from the inspected application,
+ * so the token has to survive a plain URL round trip.
+ */
+export const ACCESS_TOKEN_QUERY_PARAM = '__inspector_token';
+
+/** Dedicated header accepted alongside `Authorization: Bearer`. */
+export const ACCESS_TOKEN_HEADER = 'x-graph-inspector-token';
+
+/** Three hours: long enough for a working session, short enough to expire. */
+export const DEFAULT_ACCESS_TOKEN_TTL_MS = 3 * 60 * 60 * 1000;
+
+const TOKEN_PREFIX = 'ngi1';
+const SECRET_ENV_KEY = 'NEST_GRAPH_INSPECTOR_TOKEN_SECRET';
+
+export type AccessTokenPayload = {
+  /** Issued at, epoch milliseconds. */
+  iat: number;
+  /** Expires at, epoch milliseconds. */
+  exp: number;
+  /** Token id, so two tokens issued in the same millisecond still differ. */
+  jti: string;
+};
+
+export type AccessTokenRejection =
+  | 'missing'
+  | 'malformed'
+  | 'signature'
+  | 'expired';
+
+export type AccessTokenVerification =
+  | { ok: true; payload: AccessTokenPayload }
+  | { ok: false; reason: AccessTokenRejection };
+
+const REJECTION_MESSAGES: Record<AccessTokenRejection, string> = {
+  missing:
+    'Graph inspector access token is required. Open the viewer link printed in the application console.',
+  malformed: 'Graph inspector access token is malformed.',
+  signature: 'Graph inspector access token is not valid for this application.',
+  expired:
+    'Graph inspector access token has expired. Restart the application to print a fresh viewer link.',
+};
+
+/**
+ * Issues and verifies the short-lived tokens that gate every inspector
+ * endpoint.
+ *
+ * Tokens are self-describing: the payload carries its own expiry and an
+ * HMAC-SHA256 signature proves the payload was issued by this process. That
+ * keeps verification stateless, so an expired token dies on its own clock
+ * rather than relying on server-side bookkeeping.
+ */
+@Injectable()
+export class AccessTokenService {
+  private readonly enabled: boolean;
+  private readonly secret: Buffer;
+  readonly ttlMs: number;
+  private issued: { token: string; payload: AccessTokenPayload } | undefined;
+
+  constructor(
+    @Optional()
+    @Inject(MODULE_OPTIONS_TOKEN)
+    options?: NestGraphInspectorModuleOptions,
+  ) {
+    const accessToken = options?.accessToken;
+
+    this.enabled = accessToken?.enabled ?? true;
+    this.ttlMs = this.normalizeTtlMs(accessToken?.ttlMs);
+    this.secret = this.resolveSecret(accessToken?.secret);
+  }
+
+  isEnabled(): boolean {
+    return this.enabled;
+  }
+
+  /**
+   * The token to hand out right now, minting a fresh one once the previous
+   * token has expired.
+   */
+  current(): string {
+    if (!this.issued || this.issued.payload.exp <= this.now()) {
+      this.issued = this.mint();
+    }
+
+    return this.issued.token;
+  }
+
+  /** Expiry of the token {@link current} would return, as a Date. */
+  currentExpiresAt(): Date {
+    this.current();
+
+    return new Date(this.currentPayload().exp);
+  }
+
+  private currentPayload(): AccessTokenPayload {
+    if (!this.issued) {
+      this.issued = this.mint();
+    }
+
+    return this.issued.payload;
+  }
+
+  verify(token: string | undefined): AccessTokenVerification {
+    if (!token) {
+      return { ok: false, reason: 'missing' };
+    }
+
+    const separatorIndex = token.lastIndexOf('.');
+    if (separatorIndex === -1) {
+      return { ok: false, reason: 'malformed' };
+    }
+
+    const signedPart = token.slice(0, separatorIndex);
+    const signature = token.slice(separatorIndex + 1);
+
+    if (!signature || !signedPart.startsWith(`${TOKEN_PREFIX}.`)) {
+      return { ok: false, reason: 'malformed' };
+    }
+
+    if (!this.signatureMatches(signedPart, signature)) {
+      return { ok: false, reason: 'signature' };
+    }
+
+    const payload = this.decodePayload(signedPart.slice(TOKEN_PREFIX.length + 1));
+    if (!payload) {
+      return { ok: false, reason: 'malformed' };
+    }
+
+    if (payload.exp <= this.now()) {
+      return { ok: false, reason: 'expired' };
+    }
+
+    return { ok: true, payload };
+  }
+
+  /**
+   * Verifies the token attached to an inbound request.
+   *
+   * Returns `{ ok: true }` untouched when token protection is disabled, so
+   * callers can wire the guard unconditionally.
+   */
+  authorizeRequest(
+    req: http.IncomingMessage,
+  ): AccessTokenVerification | { ok: true; payload?: undefined } {
+    if (!this.enabled) {
+      return { ok: true };
+    }
+
+    return this.verify(this.readToken(req));
+  }
+
+  /** Human readable reason, safe to return in an HTTP body. */
+  rejectionMessage(reason: AccessTokenRejection): string {
+    return REJECTION_MESSAGES[reason];
+  }
+
+  /**
+   * Route guard applied to every endpoint the inspector installs.
+   *
+   * Rejections answer 401 rather than 404 so a developer holding an expired
+   * link can tell "you need a fresh token" from "wrong path".
+   */
+  createHttpGuard(): HttpServeAuthorize {
+    return (req) => {
+      const result = this.authorizeRequest(req);
+      if (result.ok) {
+        return { ok: true };
+      }
+
+      return {
+        ok: false,
+        response: {
+          statusCode: 401,
+          contentType: 'application/json; charset=utf-8',
+          headers: {
+            'www-authenticate': 'Bearer realm="nest-graph-inspector"',
+          },
+          body: {
+            ok: false,
+            reason: result.reason,
+            error: this.rejectionMessage(result.reason),
+          },
+        },
+      };
+    };
+  }
+
+  /** Appends the current token to a URL the viewer will load. */
+  appendToUrl(url: URL): URL {
+    if (!this.enabled) {
+      return url;
+    }
+
+    url.searchParams.set(ACCESS_TOKEN_QUERY_PARAM, this.current());
+
+    return url;
+  }
+
+  private readToken(req: http.IncomingMessage): string | undefined {
+    const authorization = this.headerValue(req.headers.authorization);
+    if (authorization?.toLowerCase().startsWith('bearer ')) {
+      return authorization.slice('bearer '.length).trim() || undefined;
+    }
+
+    const headerToken = this.headerValue(req.headers[ACCESS_TOKEN_HEADER]);
+    if (headerToken) {
+      return headerToken;
+    }
+
+    // `req.url` is origin-relative, so the base only exists to satisfy URL.
+    const requestUrl = new URL(req.url ?? '/', 'http://graph-inspector.invalid');
+
+    return requestUrl.searchParams.get(ACCESS_TOKEN_QUERY_PARAM) ?? undefined;
+  }
+
+  private headerValue(value: string | string[] | undefined): string | undefined {
+    const header = Array.isArray(value) ? value[0] : value;
+
+    return header?.trim() || undefined;
+  }
+
+  private mint(): { token: string; payload: AccessTokenPayload } {
+    const issuedAt = this.now();
+    const payload: AccessTokenPayload = {
+      iat: issuedAt,
+      exp: issuedAt + this.ttlMs,
+      jti: randomBytes(9).toString('base64url'),
+    };
+
+    const signedPart = `${TOKEN_PREFIX}.${Buffer.from(
+      JSON.stringify(payload),
+    ).toString('base64url')}`;
+
+    return {
+      token: `${signedPart}.${this.sign(signedPart)}`,
+      payload,
+    };
+  }
+
+  private sign(signedPart: string): string {
+    return createHmac('sha256', this.secret).update(signedPart).digest('base64url');
+  }
+
+  private signatureMatches(signedPart: string, signature: string): boolean {
+    const expected = Buffer.from(this.sign(signedPart));
+    const actual = Buffer.from(signature);
+
+    // timingSafeEqual throws on a length mismatch, which is itself a mismatch.
+    return (
+      expected.length === actual.length && timingSafeEqual(expected, actual)
+    );
+  }
+
+  private decodePayload(encoded: string): AccessTokenPayload | undefined {
+    try {
+      const payload: unknown = JSON.parse(
+        Buffer.from(encoded, 'base64url').toString('utf8'),
+      );
+
+      if (
+        typeof payload !== 'object' ||
+        payload === null ||
+        typeof (payload as AccessTokenPayload).iat !== 'number' ||
+        typeof (payload as AccessTokenPayload).exp !== 'number'
+      ) {
+        return undefined;
+      }
+
+      return payload as AccessTokenPayload;
+    } catch {
+      return undefined;
+    }
+  }
+
+  private resolveSecret(configuredSecret: string | undefined): Buffer {
+    // A stable secret keeps tokens valid across restarts, which matters for
+    // containerized apps that reboot more often than a developer reloads the
+    // viewer. Without one, every process gets its own throwaway secret.
+    const secret = configuredSecret ?? process.env[SECRET_ENV_KEY];
+
+    return secret ? Buffer.from(secret, 'utf8') : randomBytes(32);
+  }
+
+  private normalizeTtlMs(ttlMs: number | undefined): number {
+    if (typeof ttlMs !== 'number' || !Number.isFinite(ttlMs) || ttlMs <= 0) {
+      return DEFAULT_ACCESS_TOKEN_TTL_MS;
+    }
+
+    return Math.floor(ttlMs);
+  }
+
+  private now(): number {
+    return Date.now();
+  }
+}

--- a/lib/src/access-token.service.ts
+++ b/lib/src/access-token.service.ts
@@ -80,6 +80,7 @@ export class AccessTokenService {
   private readonly logger = new Logger(AccessTokenService.name);
   private readonly enabled: boolean;
   private readonly secret: Buffer;
+  private readonly logToken: boolean;
   readonly ttlMs: number;
   readonly limiter: AccessAttemptLimiter;
   private issued: { token: string; payload: AccessTokenPayload } | undefined;
@@ -92,6 +93,7 @@ export class AccessTokenService {
     const accessToken = options?.accessToken;
 
     this.enabled = accessToken?.enabled ?? true;
+    this.logToken = accessToken?.logToken ?? true;
     this.ttlMs = this.normalizeTtlMs(accessToken?.ttlMs);
     this.secret = this.resolveSecret(accessToken?.secret);
     this.limiter = new AccessAttemptLimiter(accessToken?.bruteForce);
@@ -99,6 +101,11 @@ export class AccessTokenService {
 
   isEnabled(): boolean {
     return this.enabled;
+  }
+
+  /** Whether the issued token may appear in the startup message. */
+  isTokenLoggable(): boolean {
+    return this.enabled && this.logToken;
   }
 
   /**
@@ -268,9 +275,14 @@ export class AccessTokenService {
       : address;
   }
 
-  /** Appends the current token to a URL the viewer will load. */
+  /**
+   * Appends the current token to a URL the viewer will load.
+   *
+   * Skipped when the token must stay out of logs, since the viewer link is
+   * printed: the operator supplies the token themselves in that setup.
+   */
   appendToUrl(url: URL): URL {
-    if (!this.enabled) {
+    if (!this.isTokenLoggable()) {
       return url;
     }
 

--- a/lib/src/adapters/http-output.adapter.spec.ts
+++ b/lib/src/adapters/http-output.adapter.spec.ts
@@ -7,6 +7,12 @@ import { FileOutputAdapter } from './file-output.adapter';
 import { HttpServeAdapter } from './http-serve.adapter';
 import { createInspectorEndpointInfo } from '../inspector-endpoint-info';
 import { GRAPH_OUTPUT_JSON_SCHEMA } from '../types/graph-output.schema';
+import {
+  ACCESS_TOKEN_HEADER,
+  ACCESS_TOKEN_QUERY_PARAM,
+  AccessTokenService,
+} from '../access-token.service';
+import { MODULE_OPTIONS_TOKEN } from '../nest-graph-inspector.config';
 
 const { version: packageVersion } = require('../../package.json') as {
   version: string;
@@ -21,6 +27,12 @@ type HttpResponse = {
 describe(HttpOutputAdapter.name, () => {
   let moduleRef: TestingModule;
   let adapter: HttpOutputAdapter;
+  let accessTokenService: AccessTokenService;
+  /** Every inspector endpoint is token-gated, so the happy path presents one. */
+  const get = (url: string) =>
+    httpGet(url, {
+      authorization: `Bearer ${accessTokenService.current()}`,
+    });
   const emptyCycles = () => ({
     modules: [],
     providers: [],
@@ -32,10 +44,17 @@ describe(HttpOutputAdapter.name, () => {
       new Response(JSON.stringify({ version: packageVersion })),
     );
     moduleRef = await Test.createTestingModule({
-      providers: [FileOutputAdapter, HttpServeAdapter, HttpOutputAdapter],
+      providers: [
+        FileOutputAdapter,
+        HttpServeAdapter,
+        HttpOutputAdapter,
+        AccessTokenService,
+        { provide: MODULE_OPTIONS_TOKEN, useValue: {} },
+      ],
     }).compile();
 
     adapter = moduleRef.get(HttpOutputAdapter);
+    accessTokenService = moduleRef.get(AccessTokenService);
   });
 
   afterEach(() => moduleRef.close());
@@ -52,9 +71,26 @@ describe(HttpOutputAdapter.name, () => {
     const result = await adapter.execute({} as never, config);
 
     expect(config.path).toBe('graph');
-    expect(result.message).toBe(
+    expect(result.message).toContain(
       `Graph inspector HTTP endpoints are installed at http://127.0.0.1:${port}/graph/information.json, http://127.0.0.1:${port}/graph/output.json, and http://127.0.0.1:${port}/graph/output.md`,
     );
+  });
+
+  it('states the access token once so an operator can pick it up', async () => {
+    const port = await availablePort();
+
+    const result = await adapter.execute({} as never, {
+      type: 'http',
+      host: '127.0.0.1',
+      port,
+      path: 'graph',
+    });
+    const token = /Access token \(expires at [^)]+\): (\S+)$/.exec(
+      result.message,
+    )?.[1];
+
+    expect(token).toBeTruthy();
+    expect(accessTokenService.verify(token!)).toMatchObject({ ok: true });
   });
 
   it('uses the default endpoint when no path is configured', () => {
@@ -221,11 +257,147 @@ describe(HttpOutputAdapter.name, () => {
       statusCode: 200,
     });
   });
+
+  describe('access token', () => {
+    let outputUrl: string;
+
+    beforeEach(async () => {
+      const port = await availablePort();
+      await adapter.execute({} as never, {
+        type: 'http',
+        host: '127.0.0.1',
+        port,
+        path: '/graph',
+      });
+      outputUrl = `http://127.0.0.1:${port}/graph/output.json`;
+    });
+
+    it('rejects a request that carries no token', async () => {
+      const response = await httpGet(outputUrl);
+
+      expect(response.statusCode).toBe(401);
+      expect(response.headers['www-authenticate']).toBe(
+        'Bearer realm="nest-graph-inspector"',
+      );
+      expect(JSON.parse(response.body)).toMatchObject({
+        ok: false,
+        reason: 'missing',
+      });
+    });
+
+    it('rejects a token signed by another application', async () => {
+      const foreignToken = new AccessTokenService({
+        accessToken: { secret: 'a-different-application' },
+      }).current();
+
+      const response = await httpGet(outputUrl, {
+        authorization: `Bearer ${foreignToken}`,
+      });
+
+      expect(response.statusCode).toBe(401);
+      expect(JSON.parse(response.body)).toMatchObject({ reason: 'signature' });
+    });
+
+    it('rejects a token that has passed its expiry', async () => {
+      const port = await availablePort();
+      const shortLived = await Test.createTestingModule({
+        providers: [
+          FileOutputAdapter,
+          HttpServeAdapter,
+          HttpOutputAdapter,
+          AccessTokenService,
+          {
+            // Long enough that the pre-expiry request is not a race, short
+            // enough to expire inside the test.
+            provide: MODULE_OPTIONS_TOKEN,
+            useValue: { accessToken: { ttlMs: 400 } },
+          },
+        ],
+      }).compile();
+
+      await shortLived.get(HttpOutputAdapter).execute({} as never, {
+        type: 'http',
+        host: '127.0.0.1',
+        port,
+        path: '/graph',
+      });
+
+      const token = shortLived.get(AccessTokenService).current();
+      const url = `http://127.0.0.1:${port}/graph/output.json`;
+      const authorization = { authorization: `Bearer ${token}` };
+
+      await expect(httpGet(url, authorization)).resolves.toMatchObject({
+        statusCode: 200,
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 450));
+      const response = await httpGet(url, authorization);
+
+      expect(response.statusCode).toBe(401);
+      expect(JSON.parse(response.body)).toMatchObject({ reason: 'expired' });
+
+      await shortLived.close();
+    });
+
+    it('accepts the token from the dedicated header', async () => {
+      const response = await httpGet(outputUrl, {
+        [ACCESS_TOKEN_HEADER]: accessTokenService.current(),
+      });
+
+      expect(response.statusCode).toBe(200);
+    });
+
+    it('accepts the token from the query parameter the viewer link carries', async () => {
+      const url = new URL(outputUrl);
+      url.searchParams.set(
+        ACCESS_TOKEN_QUERY_PARAM,
+        accessTokenService.current(),
+      );
+
+      const response = await httpGet(url.toString());
+
+      expect(response.statusCode).toBe(200);
+    });
+
+    it('serves the endpoint unguarded when token protection is turned off', async () => {
+      const port = await availablePort();
+      const unguarded = await Test.createTestingModule({
+        providers: [
+          FileOutputAdapter,
+          HttpServeAdapter,
+          HttpOutputAdapter,
+          AccessTokenService,
+          {
+            provide: MODULE_OPTIONS_TOKEN,
+            useValue: { accessToken: { enabled: false } },
+          },
+        ],
+      }).compile();
+
+      await unguarded.get(HttpOutputAdapter).execute({} as never, {
+        type: 'http',
+        host: '127.0.0.1',
+        port,
+        path: '/graph',
+      });
+
+      const response = await httpGet(
+        `http://127.0.0.1:${port}/graph/output.json`,
+      );
+
+      expect(response.statusCode).toBe(200);
+
+      await unguarded.close();
+    });
+  });
 });
 
-function get(url: string): Promise<HttpResponse> {
+function httpGet(
+  url: string,
+  headers: http.OutgoingHttpHeaders = {},
+): Promise<HttpResponse> {
   return new Promise((resolve, reject) => {
-    const req = http.get(url, (res) => {
+    const req = http.get(url, { headers }, (res) => {
       let body = '';
 
       res.setEncoding('utf8');

--- a/lib/src/adapters/http-output.adapter.spec.ts
+++ b/lib/src/adapters/http-output.adapter.spec.ts
@@ -359,6 +359,91 @@ describe(HttpOutputAdapter.name, () => {
       expect(response.statusCode).toBe(200);
     });
 
+    it('blocks a client that keeps guessing tokens', async () => {
+      const port = await availablePort();
+      const limited = await Test.createTestingModule({
+        providers: [
+          FileOutputAdapter,
+          HttpServeAdapter,
+          HttpOutputAdapter,
+          AccessTokenService,
+          {
+            provide: MODULE_OPTIONS_TOKEN,
+            useValue: {
+              accessToken: {
+                bruteForce: { maxFailures: 3, blockMs: 60_000 },
+              },
+            },
+          },
+        ],
+      }).compile();
+
+      await limited.get(HttpOutputAdapter).execute({} as never, {
+        type: 'http',
+        host: '127.0.0.1',
+        port,
+        path: '/graph',
+      });
+
+      const url = `http://127.0.0.1:${port}/graph/output.json`;
+      const guess = (attempt: number) =>
+        httpGet(url, { authorization: `Bearer ngi1.payload.guess${attempt}` });
+
+      // Three guesses are allowed; the third is what trips the block.
+      expect((await guess(1)).statusCode).toBe(401);
+      expect((await guess(2)).statusCode).toBe(401);
+      expect((await guess(3)).statusCode).toBe(401);
+
+      const blocked = await guess(4);
+      expect(blocked.statusCode).toBe(429);
+      expect(blocked.headers['retry-after']).toBe('60');
+      expect(JSON.parse(blocked.body)).toMatchObject({ reason: 'blocked' });
+
+      // A valid token is refused too: the block is on the client, not the token.
+      const withValidToken = await httpGet(url, {
+        authorization: `Bearer ${limited.get(AccessTokenService).current()}`,
+      });
+      expect(withValidToken.statusCode).toBe(429);
+
+      await limited.close();
+    });
+
+    it('does not count a request that presents no token as a guess', async () => {
+      const port = await availablePort();
+      const limited = await Test.createTestingModule({
+        providers: [
+          FileOutputAdapter,
+          HttpServeAdapter,
+          HttpOutputAdapter,
+          AccessTokenService,
+          {
+            provide: MODULE_OPTIONS_TOKEN,
+            useValue: { accessToken: { bruteForce: { maxFailures: 2 } } },
+          },
+        ],
+      }).compile();
+
+      await limited.get(HttpOutputAdapter).execute({} as never, {
+        type: 'http',
+        host: '127.0.0.1',
+        port,
+        path: '/graph',
+      });
+      const url = `http://127.0.0.1:${port}/graph/output.json`;
+
+      for (let attempt = 0; attempt < 5; attempt += 1) {
+        expect((await httpGet(url)).statusCode).toBe(401);
+      }
+
+      await expect(
+        httpGet(url, {
+          authorization: `Bearer ${limited.get(AccessTokenService).current()}`,
+        }),
+      ).resolves.toMatchObject({ statusCode: 200 });
+
+      await limited.close();
+    });
+
     it('serves the endpoint unguarded when token protection is turned off', async () => {
       const port = await availablePort();
       const unguarded = await Test.createTestingModule({

--- a/lib/src/adapters/http-output.adapter.spec.ts
+++ b/lib/src/adapters/http-output.adapter.spec.ts
@@ -365,26 +365,6 @@ describe(HttpOutputAdapter.name, () => {
       expect(accepted.statusCode).toBe(200);
     });
 
-    it('accepts the token from the dedicated header', async () => {
-      const response = await httpGet(outputUrl, {
-        [ACCESS_TOKEN_HEADER]: accessTokenService.current(),
-      });
-
-      expect(response.statusCode).toBe(200);
-    });
-
-    it('accepts the token from the query parameter the viewer link carries', async () => {
-      const url = new URL(outputUrl);
-      url.searchParams.set(
-        ACCESS_TOKEN_QUERY_PARAM,
-        accessTokenService.current(),
-      );
-
-      const response = await httpGet(url.toString());
-
-      expect(response.statusCode).toBe(200);
-    });
-
     it('blocks a client that keeps guessing tokens', async () => {
       const port = await availablePort();
       const limited = await createModule({

--- a/lib/src/adapters/http-output.adapter.spec.ts
+++ b/lib/src/adapters/http-output.adapter.spec.ts
@@ -13,6 +13,7 @@ import {
   AccessTokenService,
 } from '../access-token.service';
 import { MODULE_OPTIONS_TOKEN } from '../nest-graph-inspector.config';
+import type { NestGraphInspectorModuleOptions } from '../nest-graph-inspector.type';
 
 const { version: packageVersion } = require('../../package.json') as {
   version: string;
@@ -260,6 +261,27 @@ describe(HttpOutputAdapter.name, () => {
 
   describe('access token', () => {
     let outputUrl: string;
+    // Each nested module starts a real listener. They are closed from a hook
+    // so a failed assertion cannot leave one behind and hang the run.
+    const nestedModules: TestingModule[] = [];
+
+    const createModule = async (
+      options: NestGraphInspectorModuleOptions = {},
+    ) => {
+      const nested = await Test.createTestingModule({
+        providers: [
+          FileOutputAdapter,
+          HttpServeAdapter,
+          HttpOutputAdapter,
+          AccessTokenService,
+          { provide: MODULE_OPTIONS_TOKEN, useValue: options },
+        ],
+      }).compile();
+
+      nestedModules.push(nested);
+
+      return nested;
+    };
 
     beforeEach(async () => {
       const port = await availablePort();
@@ -270,6 +292,12 @@ describe(HttpOutputAdapter.name, () => {
         path: '/graph',
       });
       outputUrl = `http://127.0.0.1:${port}/graph/output.json`;
+    });
+
+    afterEach(async () => {
+      await Promise.all(
+        nestedModules.splice(0).map((nested) => nested.close()),
+      );
     });
 
     it('rejects a request that carries no token', async () => {
@@ -299,44 +327,42 @@ describe(HttpOutputAdapter.name, () => {
     });
 
     it('rejects a token that has passed its expiry', async () => {
+      // A shared secret lets the test mint a token the server will accept,
+      // so expiry is produced by minting against a past clock rather than by
+      // waiting out a short lifetime, which would race server startup.
+      const secret = 'expired-token-spec-secret-long-enough';
       const port = await availablePort();
-      const shortLived = await Test.createTestingModule({
-        providers: [
-          FileOutputAdapter,
-          HttpServeAdapter,
-          HttpOutputAdapter,
-          AccessTokenService,
-          {
-            // Long enough that the pre-expiry request is not a race, short
-            // enough to expire inside the test.
-            provide: MODULE_OPTIONS_TOKEN,
-            useValue: { accessToken: { ttlMs: 400 } },
-          },
-        ],
-      }).compile();
+      const expiring = await createModule({ accessToken: { secret } });
 
-      await shortLived.get(HttpOutputAdapter).execute({} as never, {
+      await expiring.get(HttpOutputAdapter).execute({} as never, {
         type: 'http',
         host: '127.0.0.1',
         port,
         path: '/graph',
       });
 
-      const token = shortLived.get(AccessTokenService).current();
       const url = `http://127.0.0.1:${port}/graph/output.json`;
-      const authorization = { authorization: `Bearer ${token}` };
 
-      await expect(httpGet(url, authorization)).resolves.toMatchObject({
-        statusCode: 200,
+      jest.spyOn(Date, 'now').mockReturnValue(Date.now() - 60_000);
+      const staleToken = new AccessTokenService({
+        accessToken: { secret, ttlMs: 1_000 },
+      }).current();
+      jest.restoreAllMocks();
+
+      const rejected = await httpGet(url, {
+        authorization: `Bearer ${staleToken}`,
       });
 
-      await new Promise((resolve) => setTimeout(resolve, 450));
-      const response = await httpGet(url, authorization);
+      expect(rejected.statusCode).toBe(401);
+      expect(JSON.parse(rejected.body)).toMatchObject({ reason: 'expired' });
 
-      expect(response.statusCode).toBe(401);
-      expect(JSON.parse(response.body)).toMatchObject({ reason: 'expired' });
+      // The same server accepts a token that has not expired, so the rejection
+      // is about the expiry and not about the secret.
+      const accepted = await httpGet(url, {
+        authorization: `Bearer ${expiring.get(AccessTokenService).current()}`,
+      });
 
-      await shortLived.close();
+      expect(accepted.statusCode).toBe(200);
     });
 
     it('accepts the token from the dedicated header', async () => {
@@ -361,22 +387,9 @@ describe(HttpOutputAdapter.name, () => {
 
     it('blocks a client that keeps guessing tokens', async () => {
       const port = await availablePort();
-      const limited = await Test.createTestingModule({
-        providers: [
-          FileOutputAdapter,
-          HttpServeAdapter,
-          HttpOutputAdapter,
-          AccessTokenService,
-          {
-            provide: MODULE_OPTIONS_TOKEN,
-            useValue: {
-              accessToken: {
-                bruteForce: { maxFailures: 3, blockMs: 60_000 },
-              },
-            },
-          },
-        ],
-      }).compile();
+      const limited = await createModule({
+        accessToken: { bruteForce: { maxFailures: 3, blockMs: 60_000 } },
+      });
 
       await limited.get(HttpOutputAdapter).execute({} as never, {
         type: 'http',
@@ -404,24 +417,13 @@ describe(HttpOutputAdapter.name, () => {
         authorization: `Bearer ${limited.get(AccessTokenService).current()}`,
       });
       expect(withValidToken.statusCode).toBe(429);
-
-      await limited.close();
     });
 
     it('does not count a request that presents no token as a guess', async () => {
       const port = await availablePort();
-      const limited = await Test.createTestingModule({
-        providers: [
-          FileOutputAdapter,
-          HttpServeAdapter,
-          HttpOutputAdapter,
-          AccessTokenService,
-          {
-            provide: MODULE_OPTIONS_TOKEN,
-            useValue: { accessToken: { bruteForce: { maxFailures: 2 } } },
-          },
-        ],
-      }).compile();
+      const limited = await createModule({
+        accessToken: { bruteForce: { maxFailures: 2 } },
+      });
 
       await limited.get(HttpOutputAdapter).execute({} as never, {
         type: 'http',
@@ -440,24 +442,13 @@ describe(HttpOutputAdapter.name, () => {
           authorization: `Bearer ${limited.get(AccessTokenService).current()}`,
         }),
       ).resolves.toMatchObject({ statusCode: 200 });
-
-      await limited.close();
     });
 
     it('serves the endpoint unguarded when token protection is turned off', async () => {
       const port = await availablePort();
-      const unguarded = await Test.createTestingModule({
-        providers: [
-          FileOutputAdapter,
-          HttpServeAdapter,
-          HttpOutputAdapter,
-          AccessTokenService,
-          {
-            provide: MODULE_OPTIONS_TOKEN,
-            useValue: { accessToken: { enabled: false } },
-          },
-        ],
-      }).compile();
+      const unguarded = await createModule({
+        accessToken: { enabled: false },
+      });
 
       await unguarded.get(HttpOutputAdapter).execute({} as never, {
         type: 'http',
@@ -471,8 +462,29 @@ describe(HttpOutputAdapter.name, () => {
       );
 
       expect(response.statusCode).toBe(200);
+    });
 
-      await unguarded.close();
+    it('omits the token from the startup message when logToken is off', async () => {
+      const port = await availablePort();
+      const quiet = await createModule({ accessToken: { logToken: false } });
+
+      const result = await quiet.get(HttpOutputAdapter).execute({} as never, {
+        type: 'http',
+        host: '127.0.0.1',
+        port,
+        path: '/graph',
+      });
+
+      expect(result.message).not.toContain(
+        quiet.get(AccessTokenService).current(),
+      );
+      expect(result.message).toContain('accessToken.logToken is off');
+
+      // The endpoint is still gated; the token simply has to come from
+      // somewhere other than the log.
+      await expect(
+        httpGet(`http://127.0.0.1:${port}/graph/output.json`),
+      ).resolves.toMatchObject({ statusCode: 401 });
     });
   });
 });

--- a/lib/src/adapters/http-output.adapter.ts
+++ b/lib/src/adapters/http-output.adapter.ts
@@ -6,6 +6,7 @@ import type { GraphOutput } from '../types/graph-output.type';
 import { GRAPH_OUTPUT_JSON_SCHEMA } from '../types/graph-output.schema';
 import { FileOutputAdapter } from './file-output.adapter';
 import { HttpServeAdapter } from './http-serve.adapter';
+import { AccessTokenService } from '../access-token.service';
 
 type HttpOutputConfig = Extract<NestGraphInspectorOutput, { type: 'http' }>;
 
@@ -43,6 +44,7 @@ export class HttpOutputAdapter implements OutputAdapter<HttpOutputConfig> {
   constructor(
     private readonly fileOutputAdapter: FileOutputAdapter,
     private readonly httpServeAdapter: HttpServeAdapter,
+    private readonly accessTokenService: AccessTokenService,
   ) {}
 
   async execute(
@@ -65,6 +67,7 @@ export class HttpOutputAdapter implements OutputAdapter<HttpOutputConfig> {
         origin,
         host: config.host,
         port: config.port,
+        authorize: this.accessTokenService.createHttpGuard(),
       },
       [
         httpAdapter.get(
@@ -118,8 +121,23 @@ export class HttpOutputAdapter implements OutputAdapter<HttpOutputConfig> {
     const markdownOutputUrl = new URL(markdownOutputPath, registration.origin);
 
     return {
-      message: `Graph inspector HTTP endpoints are installed at ${informationOutputUrl}, ${jsonOutputUrl}, and ${markdownOutputUrl}`,
+      message: `Graph inspector HTTP endpoints are installed at ${informationOutputUrl}, ${jsonOutputUrl}, and ${markdownOutputUrl}${this.accessTokenNotice()}`,
     };
+  }
+
+  /**
+   * These endpoints are token-gated, and this log line is the only place an
+   * operator can pick a token up, so it is stated once rather than repeated
+   * into each URL.
+   */
+  private accessTokenNotice(): string {
+    if (!this.accessTokenService.isEnabled()) {
+      return '';
+    }
+
+    return `. Access token (expires at ${this.accessTokenService
+      .currentExpiresAt()
+      .toISOString()}): ${this.accessTokenService.current()}`;
   }
 
   normalizePath(path = '/__nest-graph-inspector'): string {

--- a/lib/src/adapters/http-output.adapter.ts
+++ b/lib/src/adapters/http-output.adapter.ts
@@ -129,10 +129,18 @@ export class HttpOutputAdapter implements OutputAdapter<HttpOutputConfig> {
    * These endpoints are token-gated, and this log line is the only place an
    * operator can pick a token up, so it is stated once rather than repeated
    * into each URL.
+   *
+   * The token is a credential, so anything that captures application logs
+   * captures it too. `accessToken.logToken: false` keeps it out, at the cost
+   * of having to mint tokens from a configured secret instead.
    */
   private accessTokenNotice(): string {
     if (!this.accessTokenService.isEnabled()) {
       return '';
+    }
+
+    if (!this.accessTokenService.isTokenLoggable()) {
+      return '. These endpoints require an access token, which is not printed because accessToken.logToken is off';
     }
 
     return `. Access token (expires at ${this.accessTokenService

--- a/lib/src/adapters/http-serve.adapter.ts
+++ b/lib/src/adapters/http-serve.adapter.ts
@@ -2,10 +2,25 @@ import http from 'node:http';
 import { URL } from 'node:url';
 import { Injectable, OnModuleDestroy } from '@nestjs/common';
 
+/**
+ * Decides whether a matched route may run for the given request.
+ *
+ * Returning a rejection short-circuits the route: neither `callback` nor
+ * `rawCallback` is invoked, and the supplied response is sent instead.
+ */
+export type HttpServeAuthorize = (req: http.IncomingMessage) =>
+  | { ok: true }
+  | { ok: false; response: HttpServeResponse };
+
 export type HttpServeOptions = {
   origin?: string;
   host?: string;
   port?: number;
+  /**
+   * Applied to every route in this registration that does not carry its own
+   * `authorize`.
+   */
+  authorize?: HttpServeAuthorize;
 };
 
 export type HttpServeRoute = {
@@ -20,6 +35,7 @@ export type HttpServeRoute = {
   responseHeaders?: http.OutgoingHttpHeaders;
   contentType?: string;
   statusCode?: number;
+  authorize?: HttpServeAuthorize;
 };
 
 export type HttpServeRequest = {
@@ -55,7 +71,11 @@ export class HttpServeAdapter implements OnModuleDestroy {
     for (const route of routes) {
       const key = this.routeKey(route.type, this.normalizePath(route.path));
       const routeGroup = state.routes.get(key) ?? [];
-      routeGroup.push(route);
+      routeGroup.push(
+        options.authorize && !route.authorize
+          ? { ...route, authorize: options.authorize }
+          : route,
+      );
       state.routes.set(key, routeGroup);
     }
 
@@ -176,6 +196,21 @@ export class HttpServeAdapter implements OnModuleDestroy {
       }
 
       this.sendText(res, 404, 'Not Found');
+      return;
+    }
+
+    // A preflight carries no token of its own, so authorizing it would block
+    // the request the browser is asking permission for. The actual request
+    // that follows still has to present one.
+    const authorization = this.isCorsPreflightRequest(req)
+      ? undefined
+      : route.authorize?.(req);
+    if (authorization && !authorization.ok) {
+      this.sendResult(
+        res,
+        { type: route.type, path: route.path },
+        authorization.response,
+      );
       return;
     }
 

--- a/lib/src/adapters/proxy.adapter.ts
+++ b/lib/src/adapters/proxy.adapter.ts
@@ -3,6 +3,7 @@ import https from 'node:https';
 import { URL } from 'node:url';
 import { Injectable } from '@nestjs/common';
 import { HttpServeAdapter } from './http-serve.adapter';
+import type { HttpServeAuthorize } from './http-serve.adapter';
 import type {
   ProxyCorsOptions,
   ProxyGateway,
@@ -18,6 +19,7 @@ export class ProxyAdapter implements ProxyGateway {
     internalOptions: {
       httpAdapter?: HttpServeAdapter;
       pathPrefix?: string;
+      authorize?: HttpServeAuthorize;
     } = {},
   ): Promise<void> {
     const fromUrl = this.normalizeUrl(options.from);
@@ -31,7 +33,7 @@ export class ProxyAdapter implements ProxyGateway {
       : undefined;
 
     httpServeAdapter.register(
-      { origin: fromUrl.origin },
+      { origin: fromUrl.origin, authorize: internalOptions.authorize },
       (pathPrefix ? [pathPrefix, `${pathPrefix}/*`] : ['*']).map((path) => ({
         type: '*',
         path,

--- a/lib/src/adapters/viewer-output.adapter.spec.ts
+++ b/lib/src/adapters/viewer-output.adapter.spec.ts
@@ -30,6 +30,29 @@ describe(ViewerOutputAdapter.name, () => {
   let httpServeAdapter: HttpServeAdapter;
   let httpOutputAdapter: { execute: jest.Mock; normalizePath: jest.Mock };
   let proxyAdapter: { serve: jest.Mock; close: jest.Mock };
+  const nestedModules: TestingModule[] = [];
+
+  /** Nested modules serve HTTP, so cleanup runs from a hook, not inline. */
+  const createNestedModule = async (
+    options: Record<string, unknown>,
+  ): Promise<TestingModule> => {
+    const nested = await Test.createTestingModule({
+      providers: [
+        ViewerOutputAdapter,
+        HttpServeAdapter,
+        DirectRunOutputAdapter,
+        RuntimeTraceRecorder,
+        AccessTokenService,
+        { provide: HttpOutputAdapter, useValue: httpOutputAdapter },
+        { provide: ProxyAdapter, useValue: proxyAdapter },
+        { provide: MODULE_OPTIONS_TOKEN, useValue: options },
+      ],
+    }).compile();
+
+    nestedModules.push(nested);
+
+    return nested;
+  };
 
   beforeEach(async () => {
     httpOutputAdapter = {
@@ -67,7 +90,10 @@ describe(ViewerOutputAdapter.name, () => {
     httpServeAdapter = moduleRef.get(HttpServeAdapter);
   });
 
-  afterEach(() => moduleRef.close());
+  afterEach(async () => {
+    await Promise.all(nestedModules.splice(0).map((nested) => nested.close()));
+    await moduleRef.close();
+  });
 
   it('normalizes the graph endpoint before installing and encoding it', async () => {
     const result = await adapter.execute({} as never, {
@@ -119,21 +145,10 @@ describe(ViewerOutputAdapter.name, () => {
   });
 
   it('leaves the token out of the viewer link when logToken is off', async () => {
-    const quiet = await Test.createTestingModule({
-      providers: [
-        ViewerOutputAdapter,
-        HttpServeAdapter,
-        DirectRunOutputAdapter,
-        RuntimeTraceRecorder,
-        AccessTokenService,
-        { provide: HttpOutputAdapter, useValue: httpOutputAdapter },
-        { provide: ProxyAdapter, useValue: proxyAdapter },
-        {
-          provide: MODULE_OPTIONS_TOKEN,
-          useValue: { accessToken: { logToken: false } },
-        },
-      ],
-    }).compile();
+    // Tracked so cleanup survives a failed assertion; this module serves HTTP.
+    const quiet = await createNestedModule({
+      accessToken: { logToken: false },
+    });
 
     const result = await quiet.get(ViewerOutputAdapter).execute({} as never, {
       type: 'viewer',
@@ -148,8 +163,6 @@ describe(ViewerOutputAdapter.name, () => {
       quiet.get(AccessTokenService).current(),
     );
     expect(result.message).toContain('accessToken.logToken is off');
-
-    await quiet.close();
   });
 
   it('registers the Ollama proxy on the viewer HTTP origin', async () => {

--- a/lib/src/adapters/viewer-output.adapter.spec.ts
+++ b/lib/src/adapters/viewer-output.adapter.spec.ts
@@ -8,6 +8,20 @@ import { ProxyAdapter } from './proxy.adapter';
 import { ViewerOutputAdapter } from './viewer-output.adapter';
 import { DirectRunOutputAdapter } from './direct-run-output.adapter';
 import { RuntimeTraceRecorder } from '../runtime-trace.recorder';
+import {
+  ACCESS_TOKEN_QUERY_PARAM,
+  AccessTokenService,
+} from '../access-token.service';
+
+/** Reads back the graph endpoint the viewer link points at. */
+function decodeViewerEndpoint(message: string): URL {
+  const encoded = /\/view\/([A-Za-z0-9_-]+)/.exec(message)?.[1];
+  if (!encoded) {
+    throw new Error(`No viewer link found in message: ${message}`);
+  }
+
+  return new URL(Buffer.from(encoded, 'base64url').toString('utf8'));
+}
 
 describe(ViewerOutputAdapter.name, () => {
   let moduleRef: TestingModule;
@@ -36,6 +50,7 @@ describe(ViewerOutputAdapter.name, () => {
         HttpServeAdapter,
         DirectRunOutputAdapter,
         RuntimeTraceRecorder,
+        AccessTokenService,
         {
           provide: HttpOutputAdapter,
           useValue: httpOutputAdapter,
@@ -63,9 +78,7 @@ describe(ViewerOutputAdapter.name, () => {
         path: '/ollama',
       },
     });
-    const encodedEndpoint = Buffer.from('http://localhost:8889/graph').toString(
-      'base64url',
-    );
+    const endpoint = decodeViewerEndpoint(result.message);
 
     expect(httpOutputAdapter.execute).toHaveBeenCalledWith(
       {},
@@ -78,7 +91,30 @@ describe(ViewerOutputAdapter.name, () => {
         httpAdapter: httpServeAdapter,
       },
     );
-    expect(result.message).toContain(`/view/${encodedEndpoint}`);
+    expect(`${endpoint.origin}${endpoint.pathname}`).toBe(
+      'http://localhost:8889/graph',
+    );
+  });
+
+  it('carries an access token in the viewer link', async () => {
+    const result = await adapter.execute({} as never, {
+      type: 'viewer',
+      origin: 'http://localhost:8889',
+      path: 'graph',
+      ollama: {
+        origin: 'http://localhost:11434',
+        path: '/ollama',
+      },
+    });
+
+    const endpoint = decodeViewerEndpoint(result.message);
+    const token = endpoint.searchParams.get(ACCESS_TOKEN_QUERY_PARAM);
+
+    expect(token).toBeTruthy();
+    expect(moduleRef.get(AccessTokenService).verify(token!)).toMatchObject({
+      ok: true,
+    });
+    expect(result.message).toContain('access token expires at');
   });
 
   it('registers the Ollama proxy on the viewer HTTP origin', async () => {
@@ -106,6 +142,7 @@ describe(ViewerOutputAdapter.name, () => {
       {
         httpAdapter: httpOutputConfig.httpAdapter,
         pathPrefix: '/ollama',
+        authorize: expect.any(Function),
       },
     );
   });
@@ -143,9 +180,7 @@ describe(ViewerOutputAdapter.name, () => {
         path: '/ollama',
       },
     });
-    const encodedEndpoint = Buffer.from('http://127.0.0.1:3998/graph').toString(
-      'base64url',
-    );
+    const endpoint = decodeViewerEndpoint(result.message);
 
     expect(httpOutputAdapter.execute).toHaveBeenCalledWith(
       {},
@@ -158,7 +193,9 @@ describe(ViewerOutputAdapter.name, () => {
         httpAdapter: httpServeAdapter,
       },
     );
-    expect(result.message).toContain(`/view/${encodedEndpoint}`);
+    expect(`${endpoint.origin}${endpoint.pathname}`).toBe(
+      'http://127.0.0.1:3998/graph',
+    );
   });
 
   it('registers the configured Ollama proxy', async () => {
@@ -250,7 +287,80 @@ describe(ViewerOutputAdapter.name, () => {
       ],
     );
   });
+
+  it('refuses to invoke a provider method without a valid token', async () => {
+    const port = await availablePort();
+    const ping = jest.fn().mockReturnValue('pong');
+
+    await adapter.execute({} as never, {
+      type: 'viewer',
+      host: '127.0.0.1',
+      port,
+      path: 'graph',
+      ollama: { origin: 'http://localhost:11434', path: '/ollama' },
+      directRun: {
+        path: '/direct-run',
+        instanceLookup: () => ({ ping }),
+      },
+    } as never);
+
+    const body = JSON.stringify({
+      module: 'AppModule',
+      provider: 'AppService',
+      method: 'ping',
+    });
+    const url = `http://127.0.0.1:${port}/direct-run`;
+
+    const rejected = await post(url, body);
+    expect(rejected.statusCode).toBe(401);
+    expect(JSON.parse(rejected.body)).toMatchObject({ reason: 'missing' });
+    expect(ping).not.toHaveBeenCalled();
+
+    const accepted = await post(url, body, {
+      authorization: `Bearer ${moduleRef.get(AccessTokenService).current()}`,
+    });
+    expect(accepted.statusCode).toBe(200);
+    expect(JSON.parse(accepted.body)).toMatchObject({
+      ok: true,
+      result: 'pong',
+    });
+    expect(ping).toHaveBeenCalledTimes(1);
+  });
 });
+
+function post(
+  url: string,
+  body: string,
+  headers: http.OutgoingHttpHeaders = {},
+): Promise<{ statusCode?: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      url,
+      {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'content-length': Buffer.byteLength(body),
+          ...headers,
+        },
+      },
+      (res) => {
+        let responseBody = '';
+
+        res.setEncoding('utf8');
+        res.on('data', (chunk) => {
+          responseBody += chunk;
+        });
+        res.on('end', () =>
+          resolve({ statusCode: res.statusCode, body: responseBody }),
+        );
+      },
+    );
+
+    req.on('error', reject);
+    req.end(body);
+  });
+}
 
 function availablePort(): Promise<number> {
   return new Promise((resolve, reject) => {

--- a/lib/src/adapters/viewer-output.adapter.spec.ts
+++ b/lib/src/adapters/viewer-output.adapter.spec.ts
@@ -12,6 +12,7 @@ import {
   ACCESS_TOKEN_QUERY_PARAM,
   AccessTokenService,
 } from '../access-token.service';
+import { MODULE_OPTIONS_TOKEN } from '../nest-graph-inspector.config';
 
 /** Reads back the graph endpoint the viewer link points at. */
 function decodeViewerEndpoint(message: string): URL {
@@ -115,6 +116,40 @@ describe(ViewerOutputAdapter.name, () => {
       ok: true,
     });
     expect(result.message).toContain('access token expires at');
+  });
+
+  it('leaves the token out of the viewer link when logToken is off', async () => {
+    const quiet = await Test.createTestingModule({
+      providers: [
+        ViewerOutputAdapter,
+        HttpServeAdapter,
+        DirectRunOutputAdapter,
+        RuntimeTraceRecorder,
+        AccessTokenService,
+        { provide: HttpOutputAdapter, useValue: httpOutputAdapter },
+        { provide: ProxyAdapter, useValue: proxyAdapter },
+        {
+          provide: MODULE_OPTIONS_TOKEN,
+          useValue: { accessToken: { logToken: false } },
+        },
+      ],
+    }).compile();
+
+    const result = await quiet.get(ViewerOutputAdapter).execute({} as never, {
+      type: 'viewer',
+      origin: 'http://localhost:8889',
+      path: 'graph',
+      ollama: { origin: 'http://localhost:11434', path: '/ollama' },
+    });
+    const endpoint = decodeViewerEndpoint(result.message);
+
+    expect(endpoint.searchParams.get(ACCESS_TOKEN_QUERY_PARAM)).toBeNull();
+    expect(result.message).not.toContain(
+      quiet.get(AccessTokenService).current(),
+    );
+    expect(result.message).toContain('accessToken.logToken is off');
+
+    await quiet.close();
   });
 
   it('registers the Ollama proxy on the viewer HTTP origin', async () => {

--- a/lib/src/adapters/viewer-output.adapter.ts
+++ b/lib/src/adapters/viewer-output.adapter.ts
@@ -14,6 +14,7 @@ import { mkdir, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { RuntimeTraceRecorder } from '../runtime-trace.recorder';
 import type { RuntimeTrace } from '../types/direct-run.type';
+import { AccessTokenService } from '../access-token.service';
 
 type ViewerOutputConfig = Extract<NestGraphInspectorOutput, { type: 'viewer' }>;
 type ViewerOutputInternalConfig = ViewerOutputConfig & {
@@ -36,6 +37,7 @@ export class ViewerOutputAdapter implements OutputAdapter<ViewerOutputConfig> {
     private readonly httpServeAdapter: HttpServeAdapter,
     private readonly directRunOutputAdapter: DirectRunOutputAdapter,
     private readonly runtimeTraceRecorder: RuntimeTraceRecorder,
+    private readonly accessTokenService: AccessTokenService,
   ) {}
 
   async execute(
@@ -65,6 +67,7 @@ export class ViewerOutputAdapter implements OutputAdapter<ViewerOutputConfig> {
       {
         httpAdapter: this.httpServeAdapter,
         pathPrefix: ollama.path,
+        authorize: this.accessTokenService.createHttpGuard(),
       },
     );
 
@@ -74,6 +77,7 @@ export class ViewerOutputAdapter implements OutputAdapter<ViewerOutputConfig> {
           origin: this.httpOrigin(config),
           host: config.host,
           port: config.port,
+          authorize: this.accessTokenService.createHttpGuard(),
         },
         [
           this.directRunOutputAdapter.createRoute(
@@ -111,13 +115,19 @@ export class ViewerOutputAdapter implements OutputAdapter<ViewerOutputConfig> {
       throw err;
     }
 
-    const graphEndpoint = new URL(path, this.httpOrigin(config)).toString();
+    // The token rides in the graph endpoint URL so the hosted viewer carries
+    // it into every follow-up request without the developer copying it by hand.
+    const graphEndpoint = this.accessTokenService
+      .appendToUrl(new URL(path, this.httpOrigin(config)))
+      .toString();
     const base64Origin = Buffer.from(graphEndpoint).toString('base64url');
 
     const viewerLink = `${this.viewerBaseUrl}/view/${base64Origin}`;
 
     return {
-      message: `Graph Viewer is available at ${viewerLink}`,
+      message: this.accessTokenService.isEnabled()
+        ? `Graph Viewer is available at ${viewerLink} (access token expires at ${this.accessTokenService.currentExpiresAt().toISOString()})`
+        : `Graph Viewer is available at ${viewerLink}`,
     };
   }
 

--- a/lib/src/adapters/viewer-output.adapter.ts
+++ b/lib/src/adapters/viewer-output.adapter.ts
@@ -125,10 +125,27 @@ export class ViewerOutputAdapter implements OutputAdapter<ViewerOutputConfig> {
     const viewerLink = `${this.viewerBaseUrl}/view/${base64Origin}`;
 
     return {
-      message: this.accessTokenService.isEnabled()
-        ? `Graph Viewer is available at ${viewerLink} (access token expires at ${this.accessTokenService.currentExpiresAt().toISOString()})`
-        : `Graph Viewer is available at ${viewerLink}`,
+      message: `Graph Viewer is available at ${viewerLink}${this.accessTokenNotice()}`,
     };
+  }
+
+  /**
+   * The link above already carries the token when it may be printed. When it
+   * may not, the link is incomplete on purpose and the operator has to append
+   * a token they minted themselves.
+   */
+  private accessTokenNotice(): string {
+    if (!this.accessTokenService.isEnabled()) {
+      return '';
+    }
+
+    if (!this.accessTokenService.isTokenLoggable()) {
+      return ' (append your own access token to the endpoint, accessToken.logToken is off)';
+    }
+
+    return ` (access token expires at ${this.accessTokenService
+      .currentExpiresAt()
+      .toISOString()})`;
   }
 
   private httpOrigin(config: ViewerOutputConfig): string {

--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -3,6 +3,7 @@ export * from './nest-graph-inspector.type';
 export {
   ACCESS_TOKEN_HEADER,
   ACCESS_TOKEN_QUERY_PARAM,
+  AccessTokenService,
   DEFAULT_ACCESS_TOKEN_TTL_MS,
 } from './access-token.service';
 export {

--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -6,11 +6,21 @@ export {
   AccessTokenService,
   DEFAULT_ACCESS_TOKEN_TTL_MS,
 } from './access-token.service';
+export type {
+  AccessTokenPayload,
+  AccessTokenRejection,
+  AccessTokenVerification,
+} from './access-token.service';
 export {
+  AccessAttemptLimiter,
   DEFAULT_BLOCK_MS,
   DEFAULT_FAILURE_WINDOW_MS,
   DEFAULT_MAX_FAILURES,
   DEFAULT_MAX_TRACKED_CLIENTS,
+} from './access-attempt-limiter';
+export type {
+  AccessAttemptDecision,
+  AccessAttemptLimiterOptions,
 } from './access-attempt-limiter';
 export * from './types/graph-output.schema';
 export * from './types/graph-output.type';

--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -1,5 +1,10 @@
 export * from './nest-graph-inspector.module';
 export * from './nest-graph-inspector.type';
+export {
+  ACCESS_TOKEN_HEADER,
+  ACCESS_TOKEN_QUERY_PARAM,
+  DEFAULT_ACCESS_TOKEN_TTL_MS,
+} from './access-token.service';
 export * from './types/graph-output.schema';
 export * from './types/graph-output.type';
 export * from './types/direct-run.type';

--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -5,6 +5,12 @@ export {
   ACCESS_TOKEN_QUERY_PARAM,
   DEFAULT_ACCESS_TOKEN_TTL_MS,
 } from './access-token.service';
+export {
+  DEFAULT_BLOCK_MS,
+  DEFAULT_FAILURE_WINDOW_MS,
+  DEFAULT_MAX_FAILURES,
+  DEFAULT_MAX_TRACKED_CLIENTS,
+} from './access-attempt-limiter';
 export * from './types/graph-output.schema';
 export * from './types/graph-output.type';
 export * from './types/direct-run.type';

--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -22,6 +22,7 @@ export type {
   AccessAttemptDecision,
   AccessAttemptLimiterOptions,
 } from './access-attempt-limiter';
+export type { HttpServeAuthorize } from './adapters/http-serve.adapter';
 export * from './types/graph-output.schema';
 export * from './types/graph-output.type';
 export * from './types/direct-run.type';

--- a/lib/src/nest-graph-inspector.module.ts
+++ b/lib/src/nest-graph-inspector.module.ts
@@ -15,6 +15,7 @@ import { HttpServeAdapter } from './adapters/http-serve.adapter';
 import { DirectRunOutputAdapter } from './adapters/direct-run-output.adapter';
 import { RuntimeTraceRecorder } from './runtime-trace.recorder';
 import { SourceMetadataService } from './source-metadata.service';
+import { AccessTokenService } from './access-token.service';
 
 export const defaultOptions: NestGraphInspectorModuleOptions = {
   outputs: [
@@ -51,6 +52,7 @@ export const defaultOptions: NestGraphInspectorModuleOptions = {
     NestGraphInspectorSetup,
     DiscoveryAdapter,
     SourceMetadataService,
+    AccessTokenService,
     JsonOutputAdapter,
     FileOutputAdapter,
     HttpServeAdapter,

--- a/lib/src/nest-graph-inspector.module.ts
+++ b/lib/src/nest-graph-inspector.module.ts
@@ -62,5 +62,7 @@ export const defaultOptions: NestGraphInspectorModuleOptions = {
     DirectRunOutputAdapter,
     ViewerOutputAdapter,
   ],
+  // Applications need this to mint their own token when logToken is off.
+  exports: [AccessTokenService],
 })
 export class NestGraphInspectorModule extends ConfigurableModuleClass {}

--- a/lib/src/nest-graph-inspector.type.ts
+++ b/lib/src/nest-graph-inspector.type.ts
@@ -9,6 +9,44 @@ export type NestGraphInspectorViewerDirectRunOptions = {
   path?: string;
 };
 
+export type NestGraphInspectorBruteForceOptions = {
+  /**
+   * Whether failed token guesses are counted per client address.
+   *
+   * Defaults to `true`.
+   */
+  enabled?: boolean;
+
+  /**
+   * Invalid tokens a client may send inside one window before being blocked.
+   *
+   * Defaults to 10. A request with no token at all, or with a genuine token
+   * that has expired, is not a guess and is not counted.
+   */
+  maxFailures?: number;
+
+  /**
+   * How long failed guesses accumulate before the count resets, in
+   * milliseconds. Defaults to one minute.
+   */
+  windowMs?: number;
+
+  /**
+   * How long a blocked client is refused with `429`, in milliseconds.
+   *
+   * Defaults to fifteen minutes.
+   */
+  blockMs?: number;
+
+  /**
+   * Upper bound on how many client addresses are tracked at once.
+   *
+   * Defaults to 1000, so the tracker itself cannot be grown without limit by
+   * requests from many addresses.
+   */
+  maxTrackedClients?: number;
+};
+
 export type NestGraphInspectorAccessTokenOptions = {
   /**
    * Whether inspector endpoints require an access token.
@@ -32,8 +70,20 @@ export type NestGraphInspectorAccessTokenOptions = {
    * Defaults to the `NEST_GRAPH_INSPECTOR_TOKEN_SECRET` environment variable,
    * and falls back to a random per-process secret. Set it when tokens must
    * survive an application restart.
+   *
+   * Keep it at least 32 characters. A short secret can be recovered offline
+   * from a single leaked token, because a token exposes both the payload it
+   * signs and the signature itself.
    */
   secret?: string;
+
+  /**
+   * Per-client lockout for repeated invalid tokens.
+   *
+   * Clients are identified by socket address, not by a forwarded header,
+   * since a header can be set by the caller.
+   */
+  bruteForce?: NestGraphInspectorBruteForceOptions;
 };
 
 export type NestGraphInspectorOutput =

--- a/lib/src/nest-graph-inspector.type.ts
+++ b/lib/src/nest-graph-inspector.type.ts
@@ -35,6 +35,10 @@ export type NestGraphInspectorBruteForceOptions = {
    * How long a blocked client is refused with `429`, in milliseconds.
    *
    * Defaults to fifteen minutes.
+   *
+   * Behind a reverse proxy every request arrives with the proxy's address, so
+   * all callers share one bucket and a single attacker can lock everyone out
+   * for this long. Lower it, or set `enabled: false`, in that topology.
    */
   blockMs?: number;
 

--- a/lib/src/nest-graph-inspector.type.ts
+++ b/lib/src/nest-graph-inspector.type.ts
@@ -9,6 +9,33 @@ export type NestGraphInspectorViewerDirectRunOptions = {
   path?: string;
 };
 
+export type NestGraphInspectorAccessTokenOptions = {
+  /**
+   * Whether inspector endpoints require an access token.
+   *
+   * Defaults to `true`. Turning this off exposes the dependency graph and the
+   * direct-run endpoint to anyone who can reach the inspector port.
+   */
+  enabled?: boolean;
+
+  /**
+   * How long an issued token stays valid, in milliseconds.
+   *
+   * Defaults to three hours. A token issued at 13:00 stops working at 16:00,
+   * and the next request mints a replacement.
+   */
+  ttlMs?: number;
+
+  /**
+   * Signing secret for issued tokens.
+   *
+   * Defaults to the `NEST_GRAPH_INSPECTOR_TOKEN_SECRET` environment variable,
+   * and falls back to a random per-process secret. Set it when tokens must
+   * survive an application restart.
+   */
+  secret?: string;
+};
+
 export type NestGraphInspectorOutput =
   | {
       type: 'viewer';
@@ -52,6 +79,18 @@ export interface NestGraphInspectorModuleOptions {
    *   viewer URL and the endpoint path to enter in the viewer.
    */
   outputs?: NestGraphInspectorOutput[];
+
+  /**
+   * Access token protection for every endpoint the inspector installs.
+   *
+   * Inspector endpoints expose the application's internal structure, and the
+   * direct-run endpoint invokes live provider methods, so they are gated by a
+   * short-lived token by default. The token is embedded in the viewer link
+   * printed on startup, and can also be sent as `Authorization: Bearer`, an
+   * `x-graph-inspector-token` header, or an `__inspector_token` query
+   * parameter.
+   */
+  accessToken?: NestGraphInspectorAccessTokenOptions;
 
   /**
    * Provider names that should be hidden from module exports, provider lists,

--- a/lib/src/nest-graph-inspector.type.ts
+++ b/lib/src/nest-graph-inspector.type.ts
@@ -78,6 +78,16 @@ export type NestGraphInspectorAccessTokenOptions = {
   secret?: string;
 
   /**
+   * Whether the issued token is printed on startup. Defaults to `true`.
+   *
+   * The startup message is the only place a token is handed out, so turning
+   * this off means supplying your own `secret` and minting tokens yourself.
+   * Do that where application logs are shipped somewhere the token should not
+   * reach.
+   */
+  logToken?: boolean;
+
+  /**
    * Per-client lockout for repeated invalid tokens.
    *
    * Clients are identified by socket address, not by a forwarded header,

--- a/site/app/layouts/viewer.vue
+++ b/site/app/layouts/viewer.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { NavigationMenuItem } from '@nuxt/ui'
 import { storeToRefs } from 'pinia'
+import { decodeEndpointUrl } from '~/utils/inspector-access-token'
 
 const route = useRoute()
 const router = useRouter()
@@ -32,7 +33,7 @@ const currentDecodedUrl = computed(() => {
   if (!currentEncodedUrl.value) return ''
 
   try {
-    return atob(currentEncodedUrl.value)
+    return decodeEndpointUrl(currentEncodedUrl.value)
   } catch {
     return ''
   }

--- a/site/app/pages/view/[url]/execution-sequence.vue
+++ b/site/app/pages/view/[url]/execution-sequence.vue
@@ -5,6 +5,7 @@ import {
   resolveGraphViewerLoadSource,
   type LoadSource
 } from '~/utils/graph-viewer-analytics'
+import { withAccessToken } from '~/utils/inspector-access-token'
 
 definePageMeta({
   layout: 'viewer'
@@ -40,7 +41,7 @@ const directRunUrl = computed(() => {
       : '/direct-run'
     url.search = ''
     url.hash = ''
-    return url.toString()
+    return withAccessToken(url, decodedUrl.value).toString()
   } catch {
     return undefined
   }

--- a/site/app/pages/view/[url]/index.vue
+++ b/site/app/pages/view/[url]/index.vue
@@ -5,6 +5,7 @@ import {
   resolveGraphViewerLoadSource,
   type LoadSource
 } from '~/utils/graph-viewer-analytics'
+import { withAccessToken } from '~/utils/inspector-access-token'
 
 definePageMeta({
   layout: 'viewer'
@@ -124,7 +125,7 @@ const directRunUrl = computed(() => {
       : '/direct-run'
     url.search = ''
     url.hash = ''
-    return url.toString()
+    return withAccessToken(url, decodedUrl.value).toString()
   } catch {
     return undefined
   }

--- a/site/app/stores/graph-inspector.ts
+++ b/site/app/stores/graph-inspector.ts
@@ -1,6 +1,10 @@
 import type { GraphOutput } from 'nest-graph-inspector'
 import { defineStore } from 'pinia'
 import { requiresVersionAcknowledgement } from '~/utils/graph-inspector-version-gate'
+import {
+  decodeEndpointUrl,
+  withAccessToken
+} from '~/utils/inspector-access-token'
 
 type InspectorEndpointInfo = {
   for?: string
@@ -56,7 +60,9 @@ function resolveOriginPath(value: string, pathName: string) {
     url.search = ''
     url.hash = ''
 
-    return url.toString()
+    // Everything else in the query belongs to the graph endpoint, but the
+    // access token has to survive or the derived endpoint answers 401.
+    return withAccessToken(url, value).toString()
   } catch {
     return ''
   }
@@ -105,7 +111,7 @@ export const useGraphInspectorStore = defineStore('graph-inspector', () => {
     }
 
     try {
-      return atob(decodeURIComponent(encodedUrl.value))
+      return decodeEndpointUrl(decodeURIComponent(encodedUrl.value))
     } catch {
       return ''
     }

--- a/site/app/utils/graph-viewer-analytics.ts
+++ b/site/app/utils/graph-viewer-analytics.ts
@@ -1,3 +1,5 @@
+import { redactAccessToken } from './inspector-access-token.ts'
+
 export type LoadSource = 'initial_mount' | 'route_change' | 'manual_refresh'
 
 export function resolveGraphViewerLoadSource(hasTrackedInitialMount: boolean): LoadSource {
@@ -13,17 +15,21 @@ function parseGraphUrl(graphUrl: string) {
     }
   }
 
+  // The graph URL carries the inspector access token, which must never reach
+  // an analytics sink.
+  const safeGraphUrl = redactAccessToken(graphUrl)
+
   try {
-    const url = new URL(graphUrl)
+    const url = new URL(safeGraphUrl)
 
     return {
-      graph_url: graphUrl,
+      graph_url: safeGraphUrl,
       graph_url_host: url.host,
       graph_url_path: url.pathname
     }
   } catch {
     return {
-      graph_url: graphUrl,
+      graph_url: safeGraphUrl,
       graph_url_host: '',
       graph_url_path: ''
     }

--- a/site/app/utils/graph-viewer-analytics.ts
+++ b/site/app/utils/graph-viewer-analytics.ts
@@ -36,6 +36,18 @@ function parseGraphUrl(graphUrl: string) {
   }
 }
 
+/**
+ * Replaces the encoded endpoint in a viewer route with the route template.
+ *
+ * `/view/:url` carries the base64url graph endpoint, and that endpoint carries
+ * the access token — so the raw route path is a token in disguise. Redacting
+ * here rather than at each call site means a caller passing `route.fullPath`
+ * cannot reintroduce the leak, and the page itself is still identifiable.
+ */
+function redactViewerRoute(viewerRoute: string) {
+  return viewerRoute.replace(/^(\/view)\/[^/]+/, '$1/[url]')
+}
+
 export function createGraphViewerEventProperties(options: {
   graphUrl: string
   viewerRoute: string
@@ -45,7 +57,7 @@ export function createGraphViewerEventProperties(options: {
 }) {
   const properties = {
     ...parseGraphUrl(options.graphUrl),
-    viewer_route: options.viewerRoute,
+    viewer_route: redactViewerRoute(options.viewerRoute),
     load_source: options.loadSource
   } as {
     graph_url: string

--- a/site/app/utils/inspector-access-token.test.ts
+++ b/site/app/utils/inspector-access-token.test.ts
@@ -1,0 +1,79 @@
+import { Buffer } from 'node:buffer'
+import { strict as assert } from 'node:assert'
+import {
+  INSPECTOR_ACCESS_TOKEN_PARAM,
+  decodeEndpointUrl,
+  readAccessToken,
+  redactAccessToken,
+  withAccessToken
+} from './inspector-access-token.ts'
+import { createGraphViewerEventProperties } from './graph-viewer-analytics.ts'
+
+const TOKEN = 'ngi1.eyJpYXQiOjEsImV4cCI6Mn0.s1gn-atur_e'
+// The default host, which is what the printed viewer link uses.
+const ENDPOINT = `http://0.0.0.0:53371/__graph-inspector?${INSPECTOR_ACCESS_TOKEN_PARAM}=${TOKEN}`
+
+// The library encodes the endpoint with the base64url alphabet. Whether that
+// produces '-' or '_' depends on how the origin, path, and token align, and
+// the default origin carrying a token does produce them — which plain atob
+// would reject.
+const encoded = Buffer.from(ENDPOINT).toString('base64url')
+assert.ok(/[-_]/.test(encoded), 'expected a base64url-only alphabet in fixture')
+assert.equal(decodeEndpointUrl(encoded), ENDPOINT)
+
+// Standard base64 from btoa still decodes, so viewer links keep working.
+assert.equal(
+  decodeEndpointUrl(Buffer.from(ENDPOINT).toString('base64')),
+  ENDPOINT
+)
+
+assert.equal(readAccessToken(ENDPOINT), TOKEN)
+assert.equal(readAccessToken('http://0.0.0.0:53371/__graph-inspector'), undefined)
+assert.equal(readAccessToken('not a url'), undefined)
+
+// Derived endpoints are rebuilt from the origin, so the token must be copied on.
+const derived = new URL('http://0.0.0.0:53371/direct-run')
+assert.equal(
+  withAccessToken(derived, ENDPOINT).searchParams.get(INSPECTOR_ACCESS_TOKEN_PARAM),
+  TOKEN
+)
+
+// Redaction: the token must not survive into anything shipped off the browser.
+const redacted = redactAccessToken(ENDPOINT)
+assert.ok(!redacted.includes(TOKEN), 'redacted url still carries the token')
+assert.equal(redacted, 'http://0.0.0.0:53371/__graph-inspector')
+
+assert.equal(
+  redactAccessToken('http://0.0.0.0:53371/__graph-inspector'),
+  'http://0.0.0.0:53371/__graph-inspector'
+)
+
+// Other query parameters survive redaction.
+const withExtras = redactAccessToken(
+  `http://0.0.0.0:53371/graph?keep=1&${INSPECTOR_ACCESS_TOKEN_PARAM}=${TOKEN}&also=2`
+)
+assert.ok(!withExtras.includes(TOKEN))
+assert.ok(withExtras.includes('keep=1'))
+assert.ok(withExtras.includes('also=2'))
+
+// Unparseable input still gets scrubbed rather than passed through.
+const malformed = redactAccessToken(
+  `::not-a-url::?${INSPECTOR_ACCESS_TOKEN_PARAM}=${TOKEN}`
+)
+assert.ok(!malformed.includes(TOKEN), 'malformed url leaked the token')
+
+// The analytics payload is the sink that matters most.
+const properties = createGraphViewerEventProperties({
+  graphUrl: ENDPOINT,
+  viewerRoute: '/view/abc',
+  loadSource: 'initial_mount'
+})
+assert.ok(
+  !JSON.stringify(properties).includes(TOKEN),
+  'analytics properties leaked the access token'
+)
+assert.equal(properties.graph_url, 'http://0.0.0.0:53371/__graph-inspector')
+assert.equal(properties.graph_url_host, '0.0.0.0:53371')
+assert.equal(properties.graph_url_path, '/__graph-inspector')
+
+console.log('inspector-access-token.test.ts ok')

--- a/site/app/utils/inspector-access-token.test.ts
+++ b/site/app/utils/inspector-access-token.test.ts
@@ -62,18 +62,34 @@ const malformed = redactAccessToken(
 )
 assert.ok(!malformed.includes(TOKEN), 'malformed url leaked the token')
 
-// The analytics payload is the sink that matters most.
+// The analytics payload is the sink that matters most. The viewer route is
+// `/view/<base64url endpoint>`, so the token also reaches it encoded — asserting
+// only on the raw token would pass while the encoded one leaks.
 const properties = createGraphViewerEventProperties({
   graphUrl: ENDPOINT,
-  viewerRoute: '/view/abc',
+  viewerRoute: `/view/${encoded}/issues`,
   loadSource: 'initial_mount'
 })
+const serialized = JSON.stringify(properties)
+
+assert.ok(!serialized.includes(TOKEN), 'analytics leaked the access token')
 assert.ok(
-  !JSON.stringify(properties).includes(TOKEN),
-  'analytics properties leaked the access token'
+  !serialized.includes(encoded),
+  'analytics leaked the encoded endpoint, which contains the token'
 )
+assert.equal(properties.viewer_route, '/view/[url]/issues')
 assert.equal(properties.graph_url, 'http://0.0.0.0:53371/__graph-inspector')
 assert.equal(properties.graph_url_host, '0.0.0.0:53371')
 assert.equal(properties.graph_url_path, '/__graph-inspector')
+
+// A route with no encoded segment is left alone.
+assert.equal(
+  createGraphViewerEventProperties({
+    graphUrl: '',
+    viewerRoute: '/view',
+    loadSource: 'initial_mount'
+  }).viewer_route,
+  '/view'
+)
 
 console.log('inspector-access-token.test.ts ok')

--- a/site/app/utils/inspector-access-token.ts
+++ b/site/app/utils/inspector-access-token.ts
@@ -42,6 +42,33 @@ export function readAccessToken(endpointUrl: string): string | undefined {
 }
 
 /**
+ * Removes the access token from a URL before it leaves the browser.
+ *
+ * The token is a live credential for the inspected application, so anything
+ * that ships a graph URL onward — analytics, error reports, logs — has to send
+ * a redacted one.
+ */
+export function redactAccessToken(endpointUrl: string): string {
+  if (!endpointUrl || !endpointUrl.includes(INSPECTOR_ACCESS_TOKEN_PARAM)) {
+    return endpointUrl
+  }
+
+  try {
+    const url = new URL(endpointUrl)
+    url.searchParams.delete(INSPECTOR_ACCESS_TOKEN_PARAM)
+
+    return url.toString()
+  } catch {
+    // Not parseable as a URL, but it still mentions the parameter, so strip it
+    // textually rather than let a token through.
+    return endpointUrl.replace(
+      new RegExp(`([?&])${INSPECTOR_ACCESS_TOKEN_PARAM}=[^&#]*&?`, 'g'),
+      '$1'
+    )
+  }
+}
+
+/**
  * Copies the access token from a graph endpoint URL onto a derived URL.
  *
  * Derived URLs (`/direct-run`, `/ollama`) are rebuilt from the endpoint origin

--- a/site/app/utils/inspector-access-token.ts
+++ b/site/app/utils/inspector-access-token.ts
@@ -1,0 +1,58 @@
+/**
+ * Query parameter carrying the inspector access token.
+ *
+ * Must match `ACCESS_TOKEN_QUERY_PARAM` in the `nest-graph-inspector` library.
+ */
+export const INSPECTOR_ACCESS_TOKEN_PARAM = '__inspector_token'
+
+/**
+ * Decodes the graph endpoint URL carried in the `/view/:url` route segment.
+ *
+ * The library encodes it with Node's `base64url` alphabet, which swaps `+`
+ * and `/` for `-` and `_`. `atob` only accepts standard base64, so the
+ * alphabet is translated back and the stripped padding restored first.
+ */
+export function decodeEndpointUrl(encoded: string): string {
+  const base64 = encoded.replace(/-/g, '+').replace(/_/g, '/')
+  const paddingLength = (4 - (base64.length % 4)) % 4
+
+  return atob(base64.padEnd(base64.length + paddingLength, '='))
+}
+
+/**
+ * Reads the access token out of a graph endpoint URL.
+ *
+ * The endpoint URL is the only thing the viewer is handed, so it is also where
+ * the token travels.
+ */
+export function readAccessToken(endpointUrl: string): string | undefined {
+  if (!endpointUrl) {
+    return undefined
+  }
+
+  try {
+    const token = new URL(endpointUrl).searchParams.get(
+      INSPECTOR_ACCESS_TOKEN_PARAM
+    )
+
+    return token ?? undefined
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Copies the access token from a graph endpoint URL onto a derived URL.
+ *
+ * Derived URLs (`/direct-run`, `/ollama`) are rebuilt from the endpoint origin
+ * and would otherwise drop the token along with the rest of the query string.
+ */
+export function withAccessToken(url: URL, endpointUrl: string): URL {
+  const token = readAccessToken(endpointUrl)
+
+  if (token) {
+    url.searchParams.set(INSPECTOR_ACCESS_TOKEN_PARAM, token)
+  }
+
+  return url
+}

--- a/site/content/2.configuration/2.outputs.md
+++ b/site/content/2.configuration/2.outputs.md
@@ -14,7 +14,7 @@ Stability note: outputs beyond Web Viewer are under active iteration, and format
 ::
 
 ::callout{icon="i-lucide-key-round" color="primary"}
-The Web Viewer and HTTP outputs serve over the network, so their endpoints are gated behind a short-lived [access token](/configuration/access-token). The viewer link printed to your console already carries one.
+The Web Viewer and HTTP outputs serve over the network, so by default their endpoints are gated behind a short-lived [access token](/configuration/access-token). The viewer link printed to your console already carries one, and the gate can be turned off with `accessToken.enabled`.
 ::
 
 ## Web Viewer
@@ -97,9 +97,9 @@ With the default path, the graph is available at:
 - `/__nest-graph-inspector/output.json` for the raw JSON graph output
 - `/__nest-graph-inspector/output.md` for the markdown graph output
 
-These endpoints require an [access token](/configuration/access-token). The
-token to use is printed alongside the endpoint URLs when your application
-starts.
+Unless you turn the gate off with `accessToken.enabled`, these endpoints require
+an [access token](/configuration/access-token). The token to use is printed
+alongside the endpoint URLs when your application starts.
 
 ### API
 

--- a/site/content/2.configuration/2.outputs.md
+++ b/site/content/2.configuration/2.outputs.md
@@ -13,6 +13,10 @@ navigation:
 Stability note: outputs beyond Web Viewer are under active iteration, and format-level breaking changes may land between releases while we shape the long-term contract. For dependable day-to-day usage, you can always upgrade to the latest Nest Graph Inspector version to stay aligned with the Viewer experience.
 ::
 
+::callout{icon="i-lucide-key-round" color="primary"}
+The Web Viewer and HTTP outputs serve over the network, so their endpoints are gated behind a short-lived [access token](/configuration/access-token). The viewer link printed to your console already carries one.
+::
+
 ## Web Viewer
 
 ### Usage
@@ -92,6 +96,10 @@ With the default path, the graph is available at:
 - `/__nest-graph-inspector` for the JSON graph endpoint used by the viewer
 - `/__nest-graph-inspector/output.json` for the raw JSON graph output
 - `/__nest-graph-inspector/output.md` for the markdown graph output
+
+These endpoints require an [access token](/configuration/access-token). The
+token to use is printed alongside the endpoint URLs when your application
+starts.
 
 ### API
 

--- a/site/content/2.configuration/4.access-token.md
+++ b/site/content/2.configuration/4.access-token.md
@@ -9,16 +9,18 @@ navigation:
 
 Nest Graph Inspector installs its endpoints on a native HTTP server inside your
 running application. Those endpoints expose your application's internal
-structure, and the Direct Run endpoint invokes live provider methods, so every
-one of them is gated behind a short-lived access token.
+structure, and the Direct Run endpoint invokes live provider methods, so by
+default every one of them is gated behind a short-lived access token.
 
-Token protection is on by default. You do not need to configure anything.
+Token protection is on unless you set `accessToken.enabled` to `false`. You do
+not need to configure anything.
 
 ```ts
 accessToken?: {
   enabled?: boolean
   ttlMs?: number
   secret?: string
+  logToken?: boolean
   bruteForce?: { /* see below */ }
 }
 ```
@@ -39,7 +41,11 @@ curl 'http://localhost:53371/__graph-inspector/output.json?__inspector_token=<to
 ```
 
 A request without a valid token is answered with `401` and a JSON body naming
-the reason: `missing`, `malformed`, `signature`, or `expired`.
+the reason: `missing`, `malformed`, `signature`, or `expired`. Two cases do not
+answer `401`: a caller that has been locked out for repeated guesses gets `429`
+instead (see below), and a CORS preflight (`OPTIONS`) is not gated at all,
+because it carries no token of its own and blocking it would stop the browser
+from ever sending the request it is asking about.
 
 ### Expiry
 
@@ -65,6 +71,13 @@ warns at startup when a configured secret is under 32 characters.
 The other real risk is leakage rather than guessing. A token placed in a URL
 travels into access logs, proxy logs, and browser history, so treat a token as
 you would a password and prefer the header form for anything scripted.
+
+The startup message is itself one of those places. It is the only channel that
+hands a token out, so it prints one by default, which means anything collecting
+your application logs collects a working credential along with it. Where that
+matters, set `logToken: false`: the token is then left out of the message and
+out of the printed viewer link, and you supply your own by configuring a
+`secret` and minting tokens with the exported `AccessTokenService`.
 
 ### Brute force lockout
 
@@ -116,6 +129,7 @@ effectively global.
 | `enabled?: boolean` | Whether inspector endpoints require a token. Defaults to `true`. | Lets you opt out on a host where the inspector port is already unreachable from outside. |
 | `ttlMs?: number` | How long an issued token stays valid, in milliseconds. Defaults to three hours. | Matches the token lifetime to how long a debugging session actually lasts. |
 | `secret?: string` | Signing secret, 32 characters or more. Defaults to the `NEST_GRAPH_INSPECTOR_TOKEN_SECRET` environment variable, then to a random per-process secret. | Keeps issued tokens valid across restarts, which matters for containers that reboot often. |
+| `logToken?: boolean` | Whether the issued token is printed on startup. Defaults to `true`. | Keeps a live credential out of shipped application logs when set to `false`, at the cost of minting tokens yourself. |
 | `bruteForce?: object` | Per-client lockout for repeated invalid tokens. See above. | Caps how fast an attacker can try at all, and surfaces the attempt as a logged block. |
 
 ### Example

--- a/site/content/2.configuration/4.access-token.md
+++ b/site/content/2.configuration/4.access-token.md
@@ -1,0 +1,76 @@
+---
+title: Access Token
+description: Gate every inspector endpoint behind a short-lived token.
+navigation:
+  icon: i-lucide-key-round
+---
+
+## Access Token
+
+Nest Graph Inspector installs its endpoints on a native HTTP server inside your
+running application. Those endpoints expose your application's internal
+structure, and the Direct Run endpoint invokes live provider methods, so every
+one of them is gated behind a short-lived access token.
+
+Token protection is on by default. You do not need to configure anything.
+
+```ts
+accessToken?: {
+  enabled?: boolean
+  ttlMs?: number
+  secret?: string
+}
+```
+
+### How a token travels
+
+A token is issued when your application starts and is embedded directly in the
+viewer link printed to your console, so opening that link just works. The viewer
+carries the same token into every follow-up request it makes, including the
+Ollama proxy and Direct Run.
+
+When you call the endpoints yourself, send the token any of these ways:
+
+```bash
+curl -H 'Authorization: Bearer <token>' http://localhost:53371/__graph-inspector/output.json
+curl -H 'x-graph-inspector-token: <token>' http://localhost:53371/__graph-inspector/output.json
+curl 'http://localhost:53371/__graph-inspector/output.json?__inspector_token=<token>'
+```
+
+A request without a valid token is answered with `401` and a JSON body naming
+the reason: `missing`, `malformed`, `signature`, or `expired`.
+
+### Expiry
+
+A token carries its own expiry. Issued at 13:00 with the default lifetime, it
+stops working at 16:00 — the payload is signed, so the expiry cannot be edited
+without invalidating the token.
+
+Once a token expires, restart the application to print a fresh viewer link.
+
+### API
+
+| API | Description | Benefit |
+| --- | --- | --- |
+| `enabled?: boolean` | Whether inspector endpoints require a token. Defaults to `true`. | Lets you opt out on a host where the inspector port is already unreachable from outside. |
+| `ttlMs?: number` | How long an issued token stays valid, in milliseconds. Defaults to three hours. | Matches the token lifetime to how long a debugging session actually lasts. |
+| `secret?: string` | Signing secret. Defaults to the `NEST_GRAPH_INSPECTOR_TOKEN_SECRET` environment variable, then to a random per-process secret. | Keeps issued tokens valid across restarts, which matters for containers that reboot often. |
+
+### Example
+
+```ts
+NestGraphInspectorModule.forRoot({
+  outputs: [{ type: 'viewer' }],
+  accessToken: {
+    ttlMs: 30 * 60 * 1000,
+    secret: process.env.INSPECTOR_SECRET,
+  },
+})
+```
+
+::callout{icon="i-lucide-shield-alert" color="warning"}
+Turning `enabled` off removes the only check in front of the Direct Run
+endpoint, which executes provider methods against your running application with
+its real database connections. Leave it on unless the port is unreachable from
+anywhere you do not control.
+::

--- a/site/content/2.configuration/4.access-token.md
+++ b/site/content/2.configuration/4.access-token.md
@@ -19,6 +19,7 @@ accessToken?: {
   enabled?: boolean
   ttlMs?: number
   secret?: string
+  bruteForce?: { /* see below */ }
 }
 ```
 
@@ -48,13 +49,74 @@ without invalidating the token.
 
 Once a token expires, restart the application to print a fresh viewer link.
 
+### Can a token be guessed?
+
+Not by trying. A token is accepted only if its HMAC-SHA256 signature checks
+out, which means guessing one means guessing a 256-bit value.
+
+The part worth your attention is the signing secret. Left unset, it is 32
+random bytes generated per process and there is nothing to guess. If you set
+`secret` yourself, keep it long: a token exposes both the payload it signs and
+the resulting signature, so anyone holding a single leaked token can test
+candidate secrets offline, on their own hardware, without ever touching your
+application. A short or dictionary secret falls quickly that way. The library
+warns at startup when a configured secret is under 32 characters.
+
+The other real risk is leakage rather than guessing. A token placed in a URL
+travels into access logs, proxy logs, and browser history, so treat a token as
+you would a password and prefer the header form for anything scripted.
+
+### Brute force lockout
+
+Repeated invalid tokens from the same client address are counted, and once a
+client runs out of attempts it is refused with `429` and a `Retry-After`
+header until the block expires.
+
+```ts
+accessToken?: {
+  bruteForce?: {
+    enabled?: boolean
+    maxFailures?: number
+    windowMs?: number
+    blockMs?: number
+    maxTrackedClients?: number
+  }
+}
+```
+
+A block applies to the client, not the token: once blocked, even a valid token
+is refused until the block lifts. Other clients are unaffected.
+
+Two kinds of rejection are deliberately **not** counted as guesses:
+
+- a request with **no token at all**, which is not an attempt at one, and would
+  otherwise lock out anyone who simply opened an endpoint in a browser
+- a request with a **genuine but expired token**, which could only have come
+  from something that already held a real one
+
+Clients are identified by socket address. A forwarded header such as
+`X-Forwarded-For` is intentionally ignored, since the caller sets it: trusting
+one would let a brute force rotate past the lockout, and would let anyone lock
+out an address of their choosing. If you place the inspector behind a reverse
+proxy, every request arrives with the proxy's address and the lockout becomes
+effectively global.
+
+| API | Description | Default |
+| --- | --- | --- |
+| `enabled?: boolean` | Whether failed guesses are counted at all. | `true` |
+| `maxFailures?: number` | Invalid tokens allowed inside one window before the client is blocked. | `10` |
+| `windowMs?: number` | How long failures accumulate before the count resets. | `60000` |
+| `blockMs?: number` | How long a blocked client is refused. | `900000` |
+| `maxTrackedClients?: number` | Upper bound on tracked addresses, so the tracker cannot be grown without limit. | `1000` |
+
 ### API
 
 | API | Description | Benefit |
 | --- | --- | --- |
 | `enabled?: boolean` | Whether inspector endpoints require a token. Defaults to `true`. | Lets you opt out on a host where the inspector port is already unreachable from outside. |
 | `ttlMs?: number` | How long an issued token stays valid, in milliseconds. Defaults to three hours. | Matches the token lifetime to how long a debugging session actually lasts. |
-| `secret?: string` | Signing secret. Defaults to the `NEST_GRAPH_INSPECTOR_TOKEN_SECRET` environment variable, then to a random per-process secret. | Keeps issued tokens valid across restarts, which matters for containers that reboot often. |
+| `secret?: string` | Signing secret, 32 characters or more. Defaults to the `NEST_GRAPH_INSPECTOR_TOKEN_SECRET` environment variable, then to a random per-process secret. | Keeps issued tokens valid across restarts, which matters for containers that reboot often. |
+| `bruteForce?: object` | Per-client lockout for repeated invalid tokens. See above. | Caps how fast an attacker can try at all, and surfaces the attempt as a logged block. |
 
 ### Example
 


### PR DESCRIPTION
Every endpoint the inspector installs was reachable by anyone who could
reach its port. That surface included the full dependency graph, the
Ollama forward proxy, and the direct-run endpoint, which invokes live
provider methods on the running application.

Introduce AccessTokenService, which issues HMAC-signed tokens that carry
their own expiry. Verification is stateless: the signature proves the
payload was issued by this process, and the payload states when it dies.
A token issued at 13:00 stops working at 16:00 by default.

- add an authorize hook to HttpServeAdapter, applied per registration
  and overridable per route, that answers 401 before the route callback
  runs; CORS preflight is left alone so browsers can still ask
- guard the graph, schema, markdown, information, direct-run, direct-run
  history, and Ollama proxy endpoints
- embed the token in the viewer link so the hosted viewer keeps working
  without a manual copy, and state it once in the HTTP output log line
- accept the token as Authorization: Bearer, an x-graph-inspector-token
  header, or an __inspector_token query parameter
- carry the token onto the viewer's derived direct-run and Ollama URLs,
  which previously dropped the query string
- decode the viewer's endpoint parameter through the base64url alphabet,
  which a token in the URL now makes reachable

Configurable through the new accessToken module option: enabled, ttlMs,
and secret, the last also readable from NEST_GRAPH_INSPECTOR_TOKEN_SECRET
so tokens survive a restart.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012gaWeT1NpKSJ9UhBXv9CXj

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added short-lived access-token protection for Graph Inspector HTTP, viewer, and direct-execution endpoints.
  - Supports Bearer headers, dedicated headers, and URL query tokens.
  - Added configurable expiration, signing secrets, and per-client brute-force lockouts.
  - Viewer and startup endpoint links include token information when enabled.
- **Bug Fixes**
  - Preserved tokens during viewer navigation and execution.
  - Removed access tokens from analytics data.
  - Improved handling of expired, invalid, and unauthorized requests.
- **Documentation**
  - Added configuration, usage, expiration, security, and lockout guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->