### PR TITLE
test(lib): stop the not-awaited span assertion racing the clock

### DIFF
--- a/lib/src/nest-graph-inspector.setup.spec.ts
+++ b/lib/src/nest-graph-inspector.setup.spec.ts
@@ -690,7 +690,10 @@ describe(NestGraphInspectorSetup.name, () => {
       status: "success",
       metadata: expect.objectContaining({ awaited: false }),
     });
-    expect(productSpan?.durationMs).toBeGreaterThanOrEqual(5);
+    // Spans are timed with millisecond-granularity `Date.now()` readings, so a
+    // 5ms sleep can legitimately measure 4ms. Assert only that the span carries
+    // a real measurement instead of zero or a placeholder.
+    expect(productSpan?.durationMs).toBeGreaterThan(0);
     expect(updateSpan?.parentSpanId).toBe(trace.spans[0]?.spanId);
   });
 


### PR DESCRIPTION
## What does this change?

`lib/src/nest-graph-inspector.setup.spec.ts` — the test *"should mark not-awaited
promise spans with measured duration"* asserted `durationMs >= 5` against a
fixture that sleeps 5ms. It now asserts `durationMs > 0`. The fixture's sleep is
unchanged.

## Why?

The assertion raced the clock. Span durations are computed in
`lib/src/runtime-trace.recorder.ts` (lines 193, 268, 296) as
`Math.max(endedAtMs - startedAtMs, 0)` from millisecond-granularity `Date.now()`
readings, so a 5ms timer legitimately measures 4ms and the test fails — on any
Node version, at random. It took down the `Library on Node 20` leg of CI on #49,
a site-only change, while Node 22 and 24 passed on the same commit, and
reproduced locally on Node 24 within 5 consecutive runs of the single test.

Sampling `Math.max(Date.now() - t0, 0)` across a 5ms sleep, 3000 iterations on
Node 24:

| measured | 4ms | 5ms | 6ms | 7ms | 10ms | 14ms |
|---|---|---|---|---|---|---|
| count | 8 | 1057 | 1923 | 8 | 2 | 2 |

~0.3% land on 4 — matching the observed failure rate — and the floor is nowhere
near zero.

The assertion's intent is that a not-awaited promise span carries a *measured*
duration rather than zero or a placeholder, and `> 0` tests exactly that with
roughly 4ms of margin. A bound of `4` (the sleep minus one rounding millisecond)
also passes today, but it sits on the observed minimum, so a loaded runner could
reach it. Raising the sleep instead would have made the test slower without
covering anything the current fixture doesn't already cover.

## Area

- [x] `lib/` — the published npm package
- [ ] `demo/` — NestJS demo / development host
- [ ] `site/` — documentation site and viewer
- [ ] Repository tooling, CI, or docs

## Checklist

- [x] `pnpm run verify` passes locally (lint, typecheck, test, build)
- [x] Behavior changes in `lib/` are covered by a spec — no behavior change; this
      is a spec-only fix, and `lib/src/**` is untouched
- [x] If `lib/src/index.ts` exports changed, `docs/public-api.md` is updated — no
      export change
- [x] If the graph JSON output changed, `docs/graph-contract.md` and the viewer
      are updated together — no output change
- [x] `CHANGELOG.md` has an entry under `Unreleased` for user-visible changes —
      not user-visible; the spec file is shipped in the package's `src` but has
      no effect on consumers

## Notes for the reviewer

Verification, all on Node 24.19.0:

- the single test, 10 consecutive runs — passed every time
- `pnpm --filter nest-graph-inspector run test`, 5 consecutive runs — 109/109
  each time
- `pnpm run verify` from the repo root — clean across `lib`, `demo`, and `site`

Unrelated aside: this worktree had no `node_modules`, and `jest` fails with
`Module ts-jest in the transform option was not found` until `pnpm install`
runs — worth knowing if you reproduce the original flake by hand.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated timing test expectations to accept any positive duration, improving reliability across environments with varying clock precision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->