### PR TITLE
feat(site): render JSDoc on hover in the graph viewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ for the published history.
 
 ### Added
 
+- The viewer shows the JSDoc a class was written with. Rest the pointer on a
+  module title, a provider, or a controller and the comment above it appears
+  beside the node; a node with nothing documented shows nothing, and the ones
+  that do carry a dotted underline so you can tell them apart before hovering.
+  The card can be read and scrolled without the pointer leaving it, and "Show
+  JSDoc on hover" in the graph settings panel turns the whole thing off. The
+  graph already carried these comments — this is the first surface that renders
+  them, so no change to the library or the graph JSON was needed.
 - The documentation site's demo is now the demo application itself, running in
   your browser on the [nodepod](https://www.npmjs.com/package/@scelar/nodepod)
   runtime, rather than a graph file committed into the site. Direct Run invokes

--- a/demo/src/product/product.service.ts
+++ b/demo/src/product/product.service.ts
@@ -2,6 +2,12 @@ import { forwardRef, Inject, Injectable } from '@nestjs/common';
 import { MobileService } from '../mobile/mobile.service';
 import { ProductRepository, Product } from './product.repository';
 
+/**
+ * Product use cases, and the awkward wiring the graph is meant to reveal:
+ *
+ * - it reaches into MobileService through a property-injected forwardRef
+ * - its module imports UserModule and never uses it
+ */
 @Injectable()
 export class ProductService {
   @Inject(forwardRef(() => MobileService))

--- a/demo/src/user/user.controller.ts
+++ b/demo/src/user/user.controller.ts
@@ -2,6 +2,11 @@ import { Body, Controller, Get, Param, Post } from '@nestjs/common';
 import { UserService } from './user.service';
 import { UserSchedule } from './user.schedule';
 
+/**
+ * REST surface for the user feature.
+ *
+ * Documented here so the viewer has a controller comment to show on hover.
+ */
 @Controller('users')
 export class UserController {
   constructor(

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -487,6 +487,18 @@ Rendering stack: Vue Flow for the graph, Mermaid for sequence diagrams, Monaco
 for JSON editing, ApexCharts for timings, and LangChain + Ollama (through the
 library's proxy) for the AI chat panel.
 
+**The graph carries the application's own documentation.** Every module,
+provider and controller in `GraphOutput` may hold a `jsdoc` string —
+`SourceMetadataService` reads it from the sources with ts-morph — and
+`GraphViewer.vue` shows it in a hover card when the pointer rests on a module
+title or an item node. The library extracts a class's *description* only, so
+block tags such as `@param` never reach the viewer; `jsdoc-preview.ts` parses
+what does arrive into paragraphs and bullet lists, and a node with nothing
+documented opens no card and carries no dotted underline. The card is placed by
+`hover-card-position.ts` against the viewer's own box rather than the window's,
+because the viewer hides its overflow. It is on by default; "Show JSDoc on
+hover" in the graph settings panel turns it off.
+
 ### 3. The in-browser demo
 
 Everything the site shows as a demo — the previews in the documentation pages,

--- a/site/app/components/GraphViewer.vue
+++ b/site/app/components/GraphViewer.vue
@@ -38,6 +38,12 @@ import {
   buildDirectRunRequest,
   buildDirectRunSnapshot
 } from '~/utils/direct-run-provider'
+import {
+  hasJsDocPreview,
+  parseJsDocPreview,
+  type JsDocPreviewBlock
+} from '~/utils/jsdoc-preview'
+import { resolveHoverCardPosition } from '~/utils/hover-card-position'
 
 function normalizeDep(dep: GraphOutputDependencyRef): {
   moduleName: string
@@ -53,12 +59,36 @@ type ModuleNodeData = {
   isExpandable: boolean
   minWidth: number
   minHeight: number
+  /** Class-level JSDoc, when the library found the module's source. */
+  jsdoc?: string
 }
 
 type ItemNodeData = {
   label: string
   kind: 'controller' | 'provider'
   isExported: boolean
+  /** The module the item is declared in, shown in its JSDoc card. */
+  moduleName: string
+  /** Class-level JSDoc, when the library found the class's source. */
+  jsdoc?: string
+}
+
+/** What the JSDoc hover card is showing, and where. */
+type JsDocHoverCardState = {
+  nodeId: string
+  title: string
+  kind: 'module' | 'provider' | 'controller'
+  subtitle?: string
+  blocks: JsDocPreviewBlock[]
+  left: number
+  top: number
+  /** Which side of the node the card landed on, which it grows out of. */
+  placement: 'above' | 'below'
+  /**
+   * Position is only known once the card has been measured, so it stays hidden
+   * for the tick between being rendered and being placed.
+   */
+  isPositioned: boolean
 }
 
 type DirectRunActionRequest = {
@@ -223,6 +253,15 @@ const BRIGHT_LINE_NODE_FIXED_CLASS = 'bright-line-node--fixed'
 const BRIGHT_LINE_EDGE_CLASS = 'bright-line-edge'
 const BRIGHT_LINE_EDGE_DIMMED_CLASS = 'bright-line-edge--dimmed'
 const BRIGHT_LINE_EDGE_HIDDEN_CLASS = 'bright-line-edge--hidden'
+/** How long a pointer has to rest on a node before its JSDoc appears. */
+const JSDOC_HOVER_OPEN_DELAY_MS = 240
+/**
+ * How long the card survives the pointer leaving its node.
+ *
+ * The card is scrollable and selectable, so the pointer has to be able to
+ * travel from the node onto it without the card disappearing on the way.
+ */
+const JSDOC_HOVER_CLOSE_DELAY_MS = 140
 
 function parseModuleNameList(moduleNames: string[] | string): string[] {
   return Array.isArray(moduleNames) ? moduleNames : moduleNames.split(',')
@@ -467,6 +506,8 @@ function getModuleItemDependencyGraph(
       label: provider.name,
       kind: 'provider' as const,
       isExported: mod.exports.includes(provider.name),
+      moduleName,
+      jsdoc: provider.jsdoc,
       dependencies: provider.dependencies,
       depth: 0
     })),
@@ -475,6 +516,8 @@ function getModuleItemDependencyGraph(
       label: controller.name,
       kind: 'controller' as const,
       isExported: mod.exports.includes(controller.name),
+      moduleName,
+      jsdoc: controller.jsdoc,
       dependencies: controller.dependencies,
       depth: 0
     }))
@@ -1194,7 +1237,8 @@ function buildGraph(
         isCollapsed,
         isExpandable,
         minWidth: size.width,
-        minHeight: size.height
+        minHeight: size.height,
+        jsdoc: mod.jsdoc
       },
       style: { width: `${size.width}px`, height: `${size.height}px` },
       class: node => getBrightLineNodeClass(node.id)
@@ -1247,7 +1291,9 @@ function buildGraph(
           data: {
             label: item.label,
             kind: item.kind,
-            isExported: item.isExported
+            isExported: item.isExported,
+            moduleName: item.moduleName,
+            jsdoc: item.jsdoc
           },
           style: { width: `${NODE_WIDTH}px`, height: `${NODE_HEIGHT}px` },
           class: node => getBrightLineNodeClass(node.id)
@@ -1392,6 +1438,9 @@ const hasInitialFixedBrightLine
 const showModuleToModuleLine = ref(!hasInitialFixedBrightLine)
 const showProviderToProviderInsideModule = ref(!hasInitialFixedBrightLine)
 const showProviderToProviderAcrossModule = ref(false)
+const showJsDocOnHover = ref(true)
+const jsDocHoverCard = ref<JsDocHoverCardState | null>(null)
+const jsDocHoverCardRef = ref<HTMLElement | null>(null)
 const directRunStateByNodeId = ref<Record<string, DirectRunExecutionSnapshot>>(
   {}
 )
@@ -1697,6 +1746,174 @@ function shouldShowCircularEdgeWarning(
   )
 }
 
+/**
+ * The JSDoc hover card.
+ *
+ * A node carries the comment its class was written with, and the card is where
+ * the viewer shows it: rest on a module title, a provider or a controller, and
+ * what the author documented appears beside it. Nodes with nothing documented
+ * open nothing at all, which is what makes the card worth trusting.
+ *
+ * Anchoring is done against the viewer's own box rather than the window's,
+ * because the viewer hides its overflow — see `resolveHoverCardPosition`. The
+ * card's size is only known after it renders, so it is placed on the next tick
+ * and stays invisible until then.
+ */
+let jsDocHoverOpenTimer: ReturnType<typeof setTimeout> | undefined
+let jsDocHoverCloseTimer: ReturnType<typeof setTimeout> | undefined
+let pendingJsDocHoverNodeId: string | null = null
+
+function clearJsDocHoverTimers(): void {
+  clearTimeout(jsDocHoverOpenTimer)
+  clearTimeout(jsDocHoverCloseTimer)
+  jsDocHoverOpenTimer = undefined
+  jsDocHoverCloseTimer = undefined
+}
+
+function closeJsDocHoverCard(): void {
+  clearJsDocHoverTimers()
+  pendingJsDocHoverNodeId = null
+  jsDocHoverCard.value = null
+}
+
+/**
+ * Lets go of a node, without dropping a card the pointer may be moving onto.
+ *
+ * A card opened by another node in the meantime is left alone, so a fast sweep
+ * across the graph does not close the card it just opened.
+ */
+function scheduleJsDocHoverClose(nodeId: string): void {
+  const activeNodeId = jsDocHoverCard.value?.nodeId ?? pendingJsDocHoverNodeId
+  if (activeNodeId !== nodeId) {
+    return
+  }
+
+  clearTimeout(jsDocHoverOpenTimer)
+  jsDocHoverOpenTimer = undefined
+  clearTimeout(jsDocHoverCloseTimer)
+  jsDocHoverCloseTimer = setTimeout(() => {
+    jsDocHoverCloseTimer = undefined
+    if ((jsDocHoverCard.value?.nodeId ?? pendingJsDocHoverNodeId) === nodeId) {
+      closeJsDocHoverCard()
+    }
+  }, JSDOC_HOVER_CLOSE_DELAY_MS)
+}
+
+/** Keeps the card open while the pointer is reading it. */
+function holdJsDocHoverCard(): void {
+  clearTimeout(jsDocHoverCloseTimer)
+  jsDocHoverCloseTimer = undefined
+}
+
+function positionJsDocHoverCard(nodeId: string, anchor: HTMLElement): void {
+  const state = jsDocHoverCard.value
+  const container = graphViewerRef.value
+  const card = jsDocHoverCardRef.value
+
+  if (
+    !state
+    || state.nodeId !== nodeId
+    || !container
+    || !card
+    || !anchor.isConnected
+  ) {
+    return
+  }
+
+  const containerRect = container.getBoundingClientRect()
+  const anchorRect = anchor.getBoundingClientRect()
+  const cardRect = card.getBoundingClientRect()
+  const { left, top, placement } = resolveHoverCardPosition({
+    anchor: {
+      left: anchorRect.left - containerRect.left,
+      top: anchorRect.top - containerRect.top,
+      width: anchorRect.width,
+      height: anchorRect.height
+    },
+    viewport: { width: containerRect.width, height: containerRect.height },
+    card: { width: cardRect.width, height: cardRect.height }
+  })
+
+  jsDocHoverCard.value = { ...state, left, top, placement, isPositioned: true }
+}
+
+function openJsDocHoverCard(params: {
+  event: MouseEvent
+  nodeId: string
+  title: string
+  kind: JsDocHoverCardState['kind']
+  jsdoc: string | undefined
+  subtitle?: string
+}): void {
+  if (!showJsDocOnHover.value) {
+    return
+  }
+
+  const anchor = params.event.currentTarget
+  const blocks = parseJsDocPreview(params.jsdoc)
+  if (blocks.length === 0 || !(anchor instanceof HTMLElement)) {
+    return
+  }
+
+  clearJsDocHoverTimers()
+  pendingJsDocHoverNodeId = params.nodeId
+  jsDocHoverOpenTimer = setTimeout(() => {
+    jsDocHoverOpenTimer = undefined
+    if (pendingJsDocHoverNodeId !== params.nodeId) {
+      return
+    }
+
+    jsDocHoverCard.value = {
+      nodeId: params.nodeId,
+      title: params.title,
+      kind: params.kind,
+      subtitle: params.subtitle,
+      blocks,
+      left: 0,
+      top: 0,
+      placement: 'below',
+      isPositioned: false
+    }
+
+    void nextTick(() => {
+      positionJsDocHoverCard(params.nodeId, anchor)
+    })
+  }, JSDOC_HOVER_OPEN_DELAY_MS)
+}
+
+function openModuleJsDocHoverCard(
+  event: MouseEvent,
+  data: ModuleNodeData
+): void {
+  openJsDocHoverCard({
+    event,
+    nodeId: `module-${data.label}`,
+    title: data.label,
+    kind: 'module',
+    jsdoc: data.jsdoc
+  })
+}
+
+function openItemJsDocHoverCard(
+  event: MouseEvent,
+  nodeId: string,
+  data: ItemNodeData
+): void {
+  openJsDocHoverCard({
+    event,
+    nodeId,
+    title: data.label,
+    kind: data.kind,
+    subtitle: data.moduleName,
+    jsdoc: data.jsdoc
+  })
+}
+
+/** Whether a node has a comment to show, and so an affordance to hover it. */
+function hasJsDocHoverCard(jsdoc: string | undefined): boolean {
+  return showJsDocOnHover.value && hasJsDocPreview(jsdoc)
+}
+
 function setActiveBrightLineNode(event: NodeMouseEvent): void {
   if (!props.enableBrightLine) {
     return
@@ -1723,6 +1940,11 @@ function clearActiveBrightLineNode(event?: NodeMouseEvent): void {
   }
 }
 
+function handlePaneClick(): void {
+  closeJsDocHoverCard()
+  selectProviderNode(null)
+}
+
 function selectProviderNode(nodeId: string | null): void {
   const providerNode = nodeId ? parseProviderNodeId(nodeId) : null
 
@@ -1737,6 +1959,7 @@ function selectProviderNode(nodeId: string | null): void {
 }
 
 function handleNodeClick(event: NodeMouseEvent): void {
+  closeJsDocHoverCard()
   selectProviderNode(event.node.id)
 }
 
@@ -2797,6 +3020,8 @@ function refreshGraph(options: { preservePositions?: boolean } = {}) {
 
   activeCircularTooltipEdgeId.value = null
   activeBrightLineNodeId.value = null
+  // The card is anchored to a node this rebuild may move or drop entirely.
+  closeJsDocHoverCard()
   if (
     selectedProviderNodeId.value
     && !flowNodes.value.some(node => node.id === selectedProviderNodeId.value)
@@ -2926,11 +3151,19 @@ watch(
   }
 )
 
+watch(showJsDocOnHover, () => {
+  closeJsDocHoverCard()
+})
+
 onMounted(() => {
   syncDirectRunOn()
   setTimeout(() => {
     void centerGraph(0)
   }, 200)
+})
+
+onBeforeUnmount(() => {
+  clearJsDocHoverTimers()
 })
 
 useResizeObserver(graphViewerRef, () => {
@@ -2983,6 +3216,26 @@ useResizeObserver(graphViewerRef, () => {
               v-model="showLegends"
               label="Show Legends"
             />
+            <div class="graph-viewer-settings__row">
+              <UCheckbox
+                v-model="showJsDocOnHover"
+                label="Show JSDoc on hover"
+              />
+              <UTooltip
+                text="Show the JSDoc comment written above a module, provider, or controller when you rest the pointer on it."
+                :delay-duration="0"
+              >
+                <UButton
+                  type="button"
+                  icon="i-lucide-circle-help"
+                  color="neutral"
+                  variant="ghost"
+                  square
+                  class="graph-viewer-settings__help"
+                  aria-label="JSDoc on hover help"
+                />
+              </UTooltip>
+            </div>
             <div
               v-if="props.enableBrightLine"
               class="graph-viewer-settings__row"
@@ -3061,6 +3314,29 @@ useResizeObserver(graphViewerRef, () => {
       </div>
     </div>
 
+    <div
+      v-if="jsDocHoverCard"
+      ref="jsDocHoverCardRef"
+      class="graph-viewer-jsdoc"
+      :class="[
+        `graph-viewer-jsdoc--${jsDocHoverCard.placement}`,
+        { 'graph-viewer-jsdoc--positioned': jsDocHoverCard.isPositioned }
+      ]"
+      :style="{
+        left: `${jsDocHoverCard.left}px`,
+        top: `${jsDocHoverCard.top}px`
+      }"
+      @mouseenter="holdJsDocHoverCard"
+      @mouseleave="closeJsDocHoverCard"
+    >
+      <JsDocHoverCard
+        :title="jsDocHoverCard.title"
+        :kind="jsDocHoverCard.kind"
+        :subtitle="jsDocHoverCard.subtitle"
+        :blocks="jsDocHoverCard.blocks"
+      />
+    </div>
+
     <VueFlow
       :id="flowId"
       v-model:nodes="flowNodes"
@@ -3082,7 +3358,9 @@ useResizeObserver(graphViewerRef, () => {
       @node-mouse-enter="setActiveBrightLineNode"
       @node-mouse-leave="clearActiveBrightLineNode"
       @node-click="handleNodeClick"
-      @pane-click="selectProviderNode(null)"
+      @node-drag-start="closeJsDocHoverCard"
+      @move-start="closeJsDocHoverCard"
+      @pane-click="handlePaneClick"
     >
       <template #edge-warning="edgeProps">
         <BaseEdge
@@ -3174,7 +3452,16 @@ useResizeObserver(graphViewerRef, () => {
             'module-subgraph--expandable': moduleProps.data.isExpandable
           }"
         >
-          <div class="module-subgraph__title">
+          <div
+            class="module-subgraph__title"
+            :class="{
+              'module-subgraph__title--documented': hasJsDocHoverCard(
+                moduleProps.data.jsdoc
+              )
+            }"
+            @mouseenter="openModuleJsDocHoverCard($event, moduleProps.data)"
+            @mouseleave="scheduleJsDocHoverClose(`module-${moduleProps.data.label}`)"
+          >
             <span class="module-subgraph__label">
               {{ moduleProps.data.label }}
             </span>
@@ -3252,7 +3539,18 @@ useResizeObserver(graphViewerRef, () => {
 
         <div
           class="mermaid-node"
-          :class="`mermaid-node--${itemProps.data.kind}`"
+          :class="[
+            `mermaid-node--${itemProps.data.kind}`,
+            {
+              'mermaid-node--documented': hasJsDocHoverCard(
+                itemProps.data.jsdoc
+              )
+            }
+          ]"
+          @mouseenter="
+            openItemJsDocHoverCard($event, itemProps.id, itemProps.data)
+          "
+          @mouseleave="scheduleJsDocHoverClose(itemProps.id)"
         >
           <span class="mermaid-node__kind">
             {{ itemProps.data.kind === "controller" ? "C" : "P" }}
@@ -3694,6 +3992,54 @@ useResizeObserver(graphViewerRef, () => {
   gap: 8px;
   font-family: "Public Sans", system-ui, sans-serif;
   pointer-events: none;
+}
+
+/*
+ * The JSDoc hover card sits above the graph but inside the viewer, which hides
+ * its own overflow — `resolveHoverCardPosition` keeps it in bounds. It is
+ * interactive on purpose: a long comment scrolls, and its text can be selected.
+ */
+.graph-viewer-jsdoc {
+  position: absolute;
+  z-index: 12;
+  width: 320px;
+  max-width: calc(100% - 16px);
+  max-height: calc(100% - 16px);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  visibility: hidden;
+  opacity: 0;
+  transform: scale(0.98);
+  transform-origin: top center;
+  transition:
+    opacity 120ms ease,
+    transform 120ms ease;
+}
+
+.graph-viewer-jsdoc--above {
+  transform-origin: bottom center;
+}
+
+.graph-viewer-jsdoc--positioned {
+  visibility: visible;
+  opacity: 1;
+  transform: scale(1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .graph-viewer-jsdoc {
+    transition: none;
+    transform: none;
+  }
+}
+
+/* A dotted underline is the only hint that a node has something to say. */
+.module-subgraph__title--documented .module-subgraph__label,
+.mermaid-node--documented .mermaid-node__label {
+  text-decoration: underline dotted;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 3px;
+  text-decoration-color: color-mix(in srgb, currentColor 45%, transparent);
 }
 
 .direct-run-drawer__header {

--- a/site/app/components/JsDocHoverCard.vue
+++ b/site/app/components/JsDocHoverCard.vue
@@ -1,0 +1,147 @@
+<script setup lang="ts">
+import type { JsDocPreviewBlock } from '~/utils/jsdoc-preview'
+
+/**
+ * The JSDoc of one graph node, shown while the pointer rests on it.
+ *
+ * Purely presentational: the graph decides what is hovered and where the card
+ * goes, this decides how a comment reads once it is there.
+ */
+const props = defineProps<{
+  title: string
+  kind: 'module' | 'provider' | 'controller'
+  blocks: JsDocPreviewBlock[]
+  /** The owning module, for a provider or a controller. */
+  subtitle?: string
+}>()
+
+const KIND_LABELS: Record<typeof props.kind, string> = {
+  module: 'Module',
+  provider: 'Provider',
+  controller: 'Controller'
+}
+
+const KIND_ICONS: Record<typeof props.kind, string> = {
+  module: 'i-lucide-package',
+  provider: 'i-lucide-cog',
+  controller: 'i-lucide-route'
+}
+</script>
+
+<template>
+  <div
+    class="jsdoc-hover-card"
+    role="tooltip"
+  >
+    <div class="jsdoc-hover-card__header">
+      <UIcon
+        :name="KIND_ICONS[props.kind]"
+        class="jsdoc-hover-card__icon"
+        aria-hidden="true"
+      />
+      <div class="min-w-0">
+        <p class="jsdoc-hover-card__title">
+          {{ props.title }}
+        </p>
+        <p class="jsdoc-hover-card__subtitle">
+          {{ props.subtitle ? `${KIND_LABELS[props.kind]} · ${props.subtitle}` : KIND_LABELS[props.kind] }}
+        </p>
+      </div>
+    </div>
+
+    <div class="jsdoc-hover-card__body">
+      <template
+        v-for="(block, index) in props.blocks"
+        :key="index"
+      >
+        <p
+          v-if="block.kind === 'paragraph'"
+          class="jsdoc-hover-card__paragraph"
+        >
+          {{ block.text }}
+        </p>
+
+        <ul
+          v-else
+          class="jsdoc-hover-card__list"
+        >
+          <li
+            v-for="(item, itemIndex) in block.items"
+            :key="itemIndex"
+          >
+            {{ item }}
+          </li>
+        </ul>
+      </template>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.jsdoc-hover-card {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px 12px;
+  border: 1px solid var(--ui-border);
+  border-radius: 8px;
+  background: var(--ui-bg);
+  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.22);
+  font-family: "Public Sans", system-ui, sans-serif;
+}
+
+.jsdoc-hover-card__header {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  min-width: 0;
+}
+
+.jsdoc-hover-card__icon {
+  flex: 0 0 auto;
+  margin-top: 2px;
+  width: 14px;
+  height: 14px;
+  color: var(--ui-text-muted);
+}
+
+.jsdoc-hover-card__title {
+  margin: 0;
+  color: var(--ui-text-highlighted);
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 1.3;
+  overflow-wrap: anywhere;
+}
+
+.jsdoc-hover-card__subtitle {
+  margin: 0;
+  color: var(--ui-text-muted);
+  font-size: 11px;
+  line-height: 1.3;
+  overflow-wrap: anywhere;
+}
+
+.jsdoc-hover-card__body {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding-top: 8px;
+  border-top: 1px solid var(--ui-border);
+  color: var(--ui-text);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.jsdoc-hover-card__paragraph {
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.jsdoc-hover-card__list {
+  margin: 0;
+  padding-left: 16px;
+  list-style: disc;
+  overflow-wrap: anywhere;
+}
+</style>

--- a/site/app/utils/hover-card-position.test.ts
+++ b/site/app/utils/hover-card-position.test.ts
@@ -1,0 +1,72 @@
+import { strict as assert } from 'node:assert'
+import { resolveHoverCardPosition } from './hover-card-position.ts'
+
+const viewport = { width: 1000, height: 600 }
+const card = { width: 320, height: 200 }
+
+// Room below: the card sits under the node, centred on it.
+assert.deepEqual(
+  resolveHoverCardPosition({
+    anchor: { left: 400, top: 100, width: 200, height: 40 },
+    viewport,
+    card
+  }),
+  { left: 340, top: 150, placement: 'below' }
+)
+
+// No room below and more above: the card flips rather than being clipped by the
+// viewer, which hides its own overflow.
+assert.deepEqual(
+  resolveHoverCardPosition({
+    anchor: { left: 400, top: 480, width: 200, height: 40 },
+    viewport,
+    card
+  }),
+  { left: 340, top: 270, placement: 'above' }
+)
+
+// A node against the left edge cannot centre the card there; it is kept inside
+// the viewer margin instead.
+assert.equal(
+  resolveHoverCardPosition({
+    anchor: { left: 0, top: 100, width: 120, height: 40 },
+    viewport,
+    card
+  }).left,
+  8
+)
+
+// Same on the right edge.
+assert.equal(
+  resolveHoverCardPosition({
+    anchor: { left: 880, top: 100, width: 120, height: 40 },
+    viewport,
+    card
+  }).left,
+  1000 - 320 - 8
+)
+
+// A card taller than the viewer has nowhere to fit, so it is pinned to the top
+// margin and left to scroll internally rather than spilling out of view.
+assert.deepEqual(
+  resolveHoverCardPosition({
+    anchor: { left: 400, top: 20, width: 200, height: 40 },
+    viewport: { width: 1000, height: 180 },
+    card: { width: 320, height: 400 }
+  }),
+  { left: 340, top: 8, placement: 'below' }
+)
+
+// Offsets and margins are configurable, and both are respected.
+assert.deepEqual(
+  resolveHoverCardPosition({
+    anchor: { left: 400, top: 100, width: 200, height: 40 },
+    viewport,
+    card,
+    anchorOffset: 24,
+    viewportMargin: 32
+  }),
+  { left: 340, top: 164, placement: 'below' }
+)
+
+console.log('hover-card-position.test.ts ok')

--- a/site/app/utils/hover-card-position.ts
+++ b/site/app/utils/hover-card-position.ts
@@ -1,0 +1,88 @@
+/**
+ * Places a hover card inside the graph viewer without letting it fall outside.
+ *
+ * The viewer clips its own overflow, so a card anchored to a node near an edge
+ * would simply be cut in half. Positions are therefore resolved against the
+ * viewer's box rather than the window's, and kept whole inside it.
+ */
+
+/** A box measured relative to the viewer, not the page. */
+export type HoverCardBox = {
+  left: number
+  top: number
+  width: number
+  height: number
+}
+
+export type HoverCardSize = {
+  width: number
+  height: number
+}
+
+export type HoverCardPosition = {
+  left: number
+  top: number
+  /** Which side of the anchor the card ended up on, for the caller's styling. */
+  placement: 'above' | 'below'
+}
+
+/** Gap between the anchor and the card. */
+const DEFAULT_ANCHOR_OFFSET = 10
+/** Gap kept between the card and the viewer's own edges. */
+const DEFAULT_VIEWPORT_MARGIN = 8
+
+function clamp(value: number, min: number, max: number): number {
+  if (max < min) {
+    return min
+  }
+
+  return Math.min(Math.max(value, min), max)
+}
+
+/**
+ * Resolves where a card of a known size should sit next to an anchor.
+ *
+ * Below the anchor is the default; the card flips above when it does not fit
+ * below and there is more room there. Either way the result is clamped into the
+ * viewer, so a card larger than the space available is pinned to the margin and
+ * scrolls internally rather than spilling out of view.
+ */
+export function resolveHoverCardPosition(params: {
+  anchor: HoverCardBox
+  viewport: HoverCardSize
+  card: HoverCardSize
+  anchorOffset?: number
+  viewportMargin?: number
+}): HoverCardPosition {
+  const {
+    anchor,
+    viewport,
+    card,
+    anchorOffset = DEFAULT_ANCHOR_OFFSET,
+    viewportMargin = DEFAULT_VIEWPORT_MARGIN
+  } = params
+
+  const spaceBelow = viewport.height - (anchor.top + anchor.height)
+  const spaceAbove = anchor.top
+  const fitsBelow = spaceBelow >= card.height + anchorOffset + viewportMargin
+  const placement
+    = fitsBelow || spaceBelow >= spaceAbove ? 'below' : 'above'
+
+  const unclampedTop
+    = placement === 'below'
+      ? anchor.top + anchor.height + anchorOffset
+      : anchor.top - anchorOffset - card.height
+
+  const left = clamp(
+    anchor.left + anchor.width / 2 - card.width / 2,
+    viewportMargin,
+    viewport.width - card.width - viewportMargin
+  )
+  const top = clamp(
+    unclampedTop,
+    viewportMargin,
+    viewport.height - card.height - viewportMargin
+  )
+
+  return { left, top, placement }
+}

--- a/site/app/utils/hover-card-position.ts
+++ b/site/app/utils/hover-card-position.ts
@@ -31,6 +31,12 @@ const DEFAULT_ANCHOR_OFFSET = 10
 /** Gap kept between the card and the viewer's own edges. */
 const DEFAULT_VIEWPORT_MARGIN = 8
 
+/**
+ * Keeps a coordinate between two bounds, preferring `min` when they cross.
+ *
+ * They cross whenever the card is larger than the space it has to fit in, and
+ * pinning that card to the near edge is what leaves it readable.
+ */
 function clamp(value: number, min: number, max: number): number {
   if (max < min) {
     return min

--- a/site/app/utils/jsdoc-preview.test.ts
+++ b/site/app/utils/jsdoc-preview.test.ts
@@ -1,0 +1,106 @@
+import { strict as assert } from 'node:assert'
+import {
+  hasJsDocPreview,
+  parseJsDocPreview,
+  type JsDocPreviewBlock
+} from './jsdoc-preview.ts'
+
+// Nothing to show is the common case: most classes carry no comment at all, and
+// the viewer must not open an empty card for them.
+for (const empty of [undefined, null, '', '   ', '\n\n', 0, {}, []]) {
+  assert.deepEqual(
+    parseJsDocPreview(empty as string | null | undefined),
+    [],
+    `${JSON.stringify(empty)} should render no blocks`
+  )
+  assert.equal(hasJsDocPreview(empty as string | null | undefined), false)
+}
+
+assert.ok(hasJsDocPreview('UserModule is example feature'))
+
+// A hard-wrapped paragraph is one paragraph: the author's line breaks were for
+// their editor's width, not the card's.
+assert.deepEqual(
+  parseJsDocPreview(
+    'This is playground root module\nthat imports the feature modules.'
+  ),
+  [
+    {
+      kind: 'paragraph',
+      text: 'This is playground root module that imports the feature modules.'
+    }
+  ]
+)
+
+// A blank line is the only paragraph break.
+assert.deepEqual(
+  parseJsDocPreview('First paragraph.\n\nSecond paragraph.'),
+  [
+    { kind: 'paragraph', text: 'First paragraph.' },
+    { kind: 'paragraph', text: 'Second paragraph.' }
+  ]
+)
+
+// Bullets keep their own shape, and a wrapped bullet stays one item.
+assert.deepEqual(
+  parseJsDocPreview(
+    [
+      'Collects:',
+      '- imported modules',
+      '* exported providers',
+      '  spanning two lines',
+      '+ registered controllers'
+    ].join('\n')
+  ),
+  [
+    { kind: 'paragraph', text: 'Collects:' },
+    {
+      kind: 'list',
+      items: [
+        'imported modules',
+        'exported providers spanning two lines',
+        'registered controllers'
+      ]
+    }
+  ] satisfies JsDocPreviewBlock[]
+)
+
+// `{@link}` has nowhere to navigate to in the viewer, so it renders as text:
+// its label when it has one, otherwise its target.
+assert.deepEqual(
+  parseJsDocPreview(
+    'Resolved with {@link forwardRef}, see {@link OrderService|the service} '
+    + 'and {@linkplain UserModule the user module}.'
+  ),
+  [
+    {
+      kind: 'paragraph',
+      text:
+        'Resolved with forwardRef, see the service and the user module.'
+    }
+  ]
+)
+
+// ts-morph strips the comment gutter, but a comment read from anywhere else may
+// still carry it — and a column of asterisks is not content.
+assert.deepEqual(
+  parseJsDocPreview(' * OrderNotificationService has a cycle.\n * Uses forwardRef.'),
+  [
+    {
+      kind: 'paragraph',
+      text: 'OrderNotificationService has a cycle. Uses forwardRef.'
+    }
+  ]
+)
+
+// Windows line endings arrive from Windows checkouts and must not survive into
+// the rendered text.
+assert.deepEqual(
+  parseJsDocPreview('First line.\r\n\r\n- one\r\n- two'),
+  [
+    { kind: 'paragraph', text: 'First line.' },
+    { kind: 'list', items: ['one', 'two'] }
+  ]
+)
+
+console.log('jsdoc-preview.test.ts ok')

--- a/site/app/utils/jsdoc-preview.test.ts
+++ b/site/app/utils/jsdoc-preview.test.ts
@@ -81,16 +81,54 @@ assert.deepEqual(
   ]
 )
 
-// ts-morph strips the comment gutter, but a comment read from anywhere else may
-// still carry it — and a column of asterisks is not content.
+// A list written entirely with `*` bullets is a list, not a comment gutter.
+// Nothing but the delimiters can tell the two apart, and a description carries
+// none — so every marker survives.
 assert.deepEqual(
-  parseJsDocPreview(' * OrderNotificationService has a cycle.\n * Uses forwardRef.'),
+  parseJsDocPreview('* imported modules\n* exported providers'),
+  [{ kind: 'list', items: ['imported modules', 'exported providers'] }]
+)
+
+// A description whose every line happens to start with `*` is still a list.
+assert.deepEqual(
+  parseJsDocPreview('* one'),
+  [{ kind: 'list', items: ['one'] }]
+)
+
+// ts-morph hands over comment text, not the comment — but one read from
+// anywhere else still arrives wrapped, and a column of asterisks is not
+// content. The delimiters are what say so.
+assert.deepEqual(
+  parseJsDocPreview(
+    '/**\n * OrderNotificationService has a cycle.\n * Uses forwardRef.\n */'
+  ),
   [
     {
       kind: 'paragraph',
       text: 'OrderNotificationService has a cycle. Uses forwardRef.'
     }
   ]
+)
+
+// A wrapped comment keeps its bullets too, gutter and marker being distinct.
+assert.deepEqual(
+  parseJsDocPreview('/**\n * Collects:\n * - imports\n * - exports\n */'),
+  [
+    { kind: 'paragraph', text: 'Collects:' },
+    { kind: 'list', items: ['imports', 'exports'] }
+  ] satisfies JsDocPreviewBlock[]
+)
+
+// A plain block comment is unwrapped the same way a doc comment is.
+assert.deepEqual(
+  parseJsDocPreview('/* Legacy note. */'),
+  [{ kind: 'paragraph', text: 'Legacy note.' }]
+)
+
+// An unterminated wrapper is not a wrapper, and must not lose its first line.
+assert.deepEqual(
+  parseJsDocPreview('/** Half a comment'),
+  [{ kind: 'paragraph', text: '/** Half a comment' }]
 )
 
 // Windows line endings arrive from Windows checkouts and must not survive into

--- a/site/app/utils/jsdoc-preview.ts
+++ b/site/app/utils/jsdoc-preview.ts
@@ -1,0 +1,150 @@
+/**
+ * Turns the `jsdoc` string carried by a graph node into something renderable.
+ *
+ * The library extracts a class's comment with ts-morph and hands over its
+ * description text — block tags such as `@param` are dropped there, so what
+ * arrives is prose: hard-wrapped lines, bullet lists, `{@link}` references, or
+ * nothing at all. The viewer shows it in a card a few hundred pixels wide, and
+ * re-wrapping an author's line breaks is the difference between a paragraph and
+ * a ragged column, so the text is parsed into blocks here rather than dropped
+ * into the DOM as-is.
+ */
+
+/** One renderable piece of a JSDoc comment. */
+export type JsDocPreviewBlock
+  = | { kind: 'paragraph', text: string }
+    | { kind: 'list', items: string[] }
+
+/** A bullet written as `-`, `*` or `+`, the way Markdown does it. */
+const LIST_ITEM_PATTERN = /^[-*+][ \t]+(.*)$/
+/** `{@link Target}`, `{@link Target label}` or `{@link Target|label}`. */
+const INLINE_LINK_PATTERN = /\{@(?:link|linkcode|linkplain)[ \t]+([^}]+)\}/g
+/** The `*` column of a comment block, in case an unstripped comment arrives. */
+const COMMENT_GUTTER_PATTERN = /^[ \t]*\*[ \t]?/
+
+/**
+ * Whether every line is prefixed the way a raw comment block is.
+ *
+ * A leading `*` is ambiguous — it opens a comment gutter and a Markdown bullet
+ * alike — so the decision is made for the comment as a whole rather than line
+ * by line: a gutter runs down every line, a bullet list does not. The cost is
+ * that a comment consisting of nothing but `*` bullets reads as prose; `-` is
+ * the bullet that survives either way.
+ */
+function hasCommentGutter(lines: string[]): boolean {
+  const contentLines = lines.filter(line => line.trim().length > 0)
+
+  return (
+    contentLines.length > 0
+    && contentLines.every(line => COMMENT_GUTTER_PATTERN.test(line))
+  )
+}
+
+/**
+ * Replaces `{@link}` references with the text a reader should see.
+ *
+ * The viewer has nowhere to navigate to — the graph knows class names, not
+ * source locations — so a link becomes its label, or its target when it has no
+ * label.
+ */
+function renderInlineLinks(text: string): string {
+  return text.replace(INLINE_LINK_PATTERN, (_match, reference: string) => {
+    const [target = '', ...rest] = reference.trim().split(/[|\s]+/)
+    return rest.length > 0 ? rest.join(' ') : target
+  })
+}
+
+function normalizeLine(line: string, stripGutter: boolean): string {
+  const withoutGutter = stripGutter
+    ? line.replace(COMMENT_GUTTER_PATTERN, '')
+    : line
+
+  return renderInlineLinks(withoutGutter).trim()
+}
+
+/** Joins a hard-wrapped paragraph back into one line the card can re-wrap. */
+function joinWrappedLines(lines: string[]): string {
+  return lines.join(' ').replace(/\s+/g, ' ').trim()
+}
+
+type PreviewParserState = {
+  blocks: JsDocPreviewBlock[]
+  paragraph: string[]
+  list: string[][]
+}
+
+function flushParagraph(state: PreviewParserState): void {
+  const text = joinWrappedLines(state.paragraph)
+  state.paragraph = []
+
+  if (text) {
+    state.blocks.push({ kind: 'paragraph', text })
+  }
+}
+
+function flushList(state: PreviewParserState): void {
+  const items = state.list
+    .map(joinWrappedLines)
+    .filter(item => item.length > 0)
+  state.list = []
+
+  if (items.length > 0) {
+    state.blocks.push({ kind: 'list', items })
+  }
+}
+
+/**
+ * Parses a class-level JSDoc comment into the blocks the hover card renders.
+ *
+ * Anything that is not a string, or holds nothing but whitespace, parses to an
+ * empty list — the caller shows no card at all in that case, rather than an
+ * empty one.
+ */
+export function parseJsDocPreview(
+  jsdoc: string | null | undefined
+): JsDocPreviewBlock[] {
+  if (typeof jsdoc !== 'string') {
+    return []
+  }
+
+  const state: PreviewParserState = { blocks: [], paragraph: [], list: [] }
+  const rawLines = jsdoc.replace(/\r\n?/g, '\n').split('\n')
+  const stripGutter = hasCommentGutter(rawLines)
+
+  for (const rawLine of rawLines) {
+    const line = normalizeLine(rawLine, stripGutter)
+
+    if (!line) {
+      flushParagraph(state)
+      flushList(state)
+      continue
+    }
+
+    const listItem = LIST_ITEM_PATTERN.exec(line)
+    if (listItem) {
+      flushParagraph(state)
+      state.list.push([listItem[1] ?? ''])
+      continue
+    }
+
+    // A continuation line belongs to whichever block is still open, so a
+    // hard-wrapped bullet does not break into prose halfway through.
+    const openListItem = state.list.at(-1)
+    if (openListItem) {
+      openListItem.push(line)
+      continue
+    }
+
+    state.paragraph.push(line)
+  }
+
+  flushParagraph(state)
+  flushList(state)
+
+  return state.blocks
+}
+
+/** Whether a `jsdoc` value has anything worth showing on hover. */
+export function hasJsDocPreview(jsdoc: string | null | undefined): boolean {
+  return parseJsDocPreview(jsdoc).length > 0
+}

--- a/site/app/utils/jsdoc-preview.ts
+++ b/site/app/utils/jsdoc-preview.ts
@@ -23,21 +23,30 @@ const INLINE_LINK_PATTERN = /\{@(?:link|linkcode|linkplain)[ \t]+([^}]+)\}/g
 const COMMENT_GUTTER_PATTERN = /^[ \t]*\*[ \t]?/
 
 /**
- * Whether every line is prefixed the way a raw comment block is.
+ * Strips a raw comment-block wrapper, or returns `null` when there is none.
  *
  * A leading `*` is ambiguous — it opens a comment gutter and a Markdown bullet
- * alike — so the decision is made for the comment as a whole rather than line
- * by line: a gutter runs down every line, a bullet list does not. The cost is
- * that a comment consisting of nothing but `*` bullets reads as prose; `-` is
- * the bullet that survives either way.
+ * alike — and guessing between them from the lines alone gets bullet lists
+ * wrong. The delimiters are not ambiguous, so they are what decides: only text
+ * that is literally a comment block has its gutter stripped, and a description
+ * written entirely as `*` bullets keeps every marker. The library hands over
+ * comment *text*, so this normally finds nothing; it is here so a comment read
+ * from somewhere else still renders.
  */
-function hasCommentGutter(lines: string[]): boolean {
-  const contentLines = lines.filter(line => line.trim().length > 0)
+function unwrapRawComment(comment: string): string | null {
+  const trimmed = comment.trim()
 
-  return (
-    contentLines.length > 0
-    && contentLines.every(line => COMMENT_GUTTER_PATTERN.test(line))
-  )
+  if (!trimmed.startsWith('/*') || !trimmed.endsWith('*/')) {
+    return null
+  }
+
+  return trimmed
+    .slice(2, -2)
+    // `/**` opens a doc comment; the third character belongs to the delimiter.
+    .replace(/^\*/, '')
+    .split('\n')
+    .map(line => line.replace(COMMENT_GUTTER_PATTERN, ''))
+    .join('\n')
 }
 
 /**
@@ -54,12 +63,9 @@ function renderInlineLinks(text: string): string {
   })
 }
 
-function normalizeLine(line: string, stripGutter: boolean): string {
-  const withoutGutter = stripGutter
-    ? line.replace(COMMENT_GUTTER_PATTERN, '')
-    : line
-
-  return renderInlineLinks(withoutGutter).trim()
+/** One line as the card should read it: links resolved, indentation gone. */
+function normalizeLine(line: string): string {
+  return renderInlineLinks(line).trim()
 }
 
 /** Joins a hard-wrapped paragraph back into one line the card can re-wrap. */
@@ -73,6 +79,7 @@ type PreviewParserState = {
   list: string[][]
 }
 
+/** Closes the paragraph being collected, dropping it when it is empty. */
 function flushParagraph(state: PreviewParserState): void {
   const text = joinWrappedLines(state.paragraph)
   state.paragraph = []
@@ -82,6 +89,7 @@ function flushParagraph(state: PreviewParserState): void {
   }
 }
 
+/** Closes the bullet list being collected, dropping it when it is empty. */
 function flushList(state: PreviewParserState): void {
   const items = state.list
     .map(joinWrappedLines)
@@ -108,11 +116,10 @@ export function parseJsDocPreview(
   }
 
   const state: PreviewParserState = { blocks: [], paragraph: [], list: [] }
-  const rawLines = jsdoc.replace(/\r\n?/g, '\n').split('\n')
-  const stripGutter = hasCommentGutter(rawLines)
+  const text = jsdoc.replace(/\r\n?/g, '\n')
 
-  for (const rawLine of rawLines) {
-    const line = normalizeLine(rawLine, stripGutter)
+  for (const rawLine of (unwrapRawComment(text) ?? text).split('\n')) {
+    const line = normalizeLine(rawLine)
 
     if (!line) {
       flushParagraph(state)

--- a/site/content/3.guide/1.how-it-works.md
+++ b/site/content/3.guide/1.how-it-works.md
@@ -22,10 +22,12 @@ For each module, the inspector gathers:
 - Exported providers
 - Registered providers
 - Registered controllers
+- The JSDoc comment written above each module, provider, and controller, read
+  from your sources
 
 ### Resolve dependencies
 For each provider and controller, the inspector resolves the constructor and property dependencies, tracing them back to their originating module.
 
 ### Generate output
-The collected data is processed and sent to all configured outputs, which can include JSON files, HTTP endpoints, or dynamically visualized in our Interactive Web Viewer.
+The collected data is processed and sent to all configured outputs, which can include JSON files, HTTP endpoints, or dynamically visualized in our Interactive Web Viewer. In the viewer, resting the pointer on a module, provider, or controller shows the JSDoc it was documented with.
 ::


### PR DESCRIPTION
## What does this change?

The viewer now shows the JSDoc a class was written with. Rest the pointer on a module title, a provider, or a controller and the comment above it appears beside the node.

## Why?

`GraphOutput` has carried a `jsdoc` string on modules, providers and controllers since schema version 3 — `SourceMetadataService` reads it out of the application's sources with ts-morph — and nothing rendered it. The graph told you the shape of an application but not what its author said about it.

**How it works**

- `site/app/utils/jsdoc-preview.ts` parses what the library emits. The library extracts a class's *description* only (`getCommentText()` drops block tags), so the parser handles prose and bullet lists, rejoins hard-wrapped author lines — a card a few hundred pixels wide should read as a paragraph, not a ragged column — and renders `{@link}` as its label.
- `site/app/utils/hover-card-position.ts` places the card against the viewer's own box rather than the window's, because `.graph-viewer` hides its overflow: it flips above the node when it does not fit below, and is clamped inside the viewer either way. The card's size is only known after it renders, so it is placed on the next tick and stays invisible until then.
- A node with nothing documented opens no card and carries no dotted underline, so the affordance means something.
- The card is interactive on purpose: a long comment scrolls and its text can be selected, and a short grace period lets the pointer travel from the node onto it.
- It closes on click, drag, pan/zoom, and any graph rebuild — the card is anchored to a node those move or drop.
- "Show JSDoc on hover" in the graph settings panel turns it off.

The demo gains a documented controller (`UserController`) and a provider whose comment carries a bullet list (`ProductService`), so the hosted demo shows the feature on all three node kinds rather than only on modules.

**Verified in a browser**, driving the real demo through the real viewer: the card opens for modules, providers and controllers; an undocumented node opens nothing; the card survives the pointer travelling onto it and closes when the pointer leaves; turning the setting off removes both the card and the underline; light and dark themes both render correctly.

Not covered: the card is pointer-driven, like the rest of the graph — graph nodes are not keyboard-focusable in the viewer today, so there is no keyboard path to it.

## Area

- [ ] `lib/` — the published npm package
- [x] `demo/` — NestJS demo / development host
- [x] `site/` — documentation site and viewer
- [x] Repository tooling, CI, or docs

## Checklist

- [x] `pnpm run verify` passes locally (lint, typecheck, test, build)
- [x] Behavior changes in `lib/` are covered by a spec — n/a, `lib/` is untouched
- [x] If `lib/src/index.ts` exports changed, `docs/public-api.md` is updated — n/a, no export changed
- [x] If the graph JSON output changed, `docs/graph-contract.md` and the viewer are updated together — n/a, the JSON is unchanged; this only reads a field it already carried
- [x] `CHANGELOG.md` has an entry under `Unreleased` for user-visible changes

`docs/architecture.md` gains a paragraph under "The interactive viewer" describing the card, and `site/content/3.guide/1.how-it-works.md` mentions it for users.

Both new utils ship with tests under the site's `node --test` suite (`jsdoc-preview.test.ts`, `hover-card-position.test.ts`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01QGcXaQoognyTPoLDbEmhv4)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added hover cards displaying JSDoc comments for documented modules, providers, and controllers in the graph viewer.
  - Added support for paragraphs, bullet lists, and link text in documentation previews.
  - Added a setting to enable or disable JSDoc previews.
  - Hover cards remain within the viewer, support scrolling, and close during graph interactions.

- **Documentation**
  - Updated the changelog, architecture guide, and usage documentation with the new feature.
  - Added sample documentation to demo components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->