### PR TITLE
docs: revalidate the debt report and adopt ECC as the coding standard

### DIFF
--- a/docs/development-guidelines.md
+++ b/docs/development-guidelines.md
@@ -342,7 +342,7 @@ framework mechanism it prescribes is unavailable, and this is what replaces it.
 | Validate every request DTO with `class-validator`; enable `whitelist` / `forbidNonWhitelisted` | No `ValidationPipe` ever runs, and `class-validator` is not a dependency of `lib/` | Hand-written validation in the adapter, with the same two guarantees: reject any key outside `['module','provider','method','args']` with a 400, and validate `args` against the `parameterTypes` the library already computes. Do not add a DTO class. |
 | Terminate on invalid env/config instead of booting partially | A library must never abort a host's boot because port 53371 was taken | Terminate the affected **capability**, not the process. Output-adapter failures stay logged and swallowed. Security-relevant misconfiguration does not: a secret shorter than the documented 32-character minimum must stop being used, not merely warn. |
 | Use-case code must not import framework types | The NestJS container is this library's subject matter and its lifecycle is the inbound adapter's trigger | `@Injectable()` and `OnModuleInit` on `NestGraphInspectorSetup` are exempt. The rule still binds to the graph-building logic inside it — cycle detection and type rendering import only `lib/src/types/**`. See TD-02. |
-| Fail fast and loudly | An output failure reaching the host would abort its boot | The failure must still reach *someone who can act*, and for a library that is the importing application. An optional `onOutputError` hook, defaulting to a no-op, satisfies ECC without changing the default. |
+| Fail fast and loudly | An output failure reaching the host would abort its boot | The failure must still reach *someone who can act*, and for a library that is the importing application. Today the only channel is a log line, which `architecture.md` itself calls "easy to miss" — so this obligation is **not** currently discharged. An optional `onOutputError` hook would give a host the means to escalate; because it must default to a no-op to preserve the invariant, ECC's requirement is met only for hosts that opt in, and that residue is deliberate. |
 
 ### Where ECC does not reach
 
@@ -377,7 +377,7 @@ silence.
 ### Running a review
 
 ```bash
-pnpm run verify   # lint + typecheck + test + build, across the workspace
+pnpm run verify   # build library → lint → typecheck → test → build workspace
 ```
 
 `verify` does **not** run the demo's e2e suites. Any change to the access token,

--- a/docs/development-guidelines.md
+++ b/docs/development-guidelines.md
@@ -265,13 +265,125 @@ Update `docs/graph-contract.md` if the contract changed.
 
 ---
 
-## Open questions
+## Coding standards
 
-- There is no monorepo-level `pnpm-workspace.yaml`; workspace membership is
-  inferred by convention. Confirm whether `lib/`, `demo/`, and `site/` are
-  officially in the same pnpm workspace.
-- The `demo/test/app.e2e-spec.ts` e2e test appears to be a scaffold
-  remnant.  It should either be updated to test the real demo app behaviour or
-  removed.
-- No CI pipeline runs the library unit tests automatically (`.github/workflows/`
-  only contains `deploy-site.yml`).  Contributors must run `pnpm test` locally.
+This project adopts the **ECC coding standards** as its baseline. They are not
+a project-specific invention and nothing here should be read as one: the source
+of truth is the ECC plugin as installed, principally
+
+- `skills/coding-standards/SKILL.md` — naming, immutability, KISS/DRY/YAGNI, error handling
+- `agents/typescript-reviewer.md` — the CRITICAL/HIGH/MEDIUM rubric for TypeScript
+- `skills/nestjs-patterns/SKILL.md` — NestJS structure and conventions
+- `skills/hexagonal-architecture/SKILL.md` — ports and adapters
+- `skills/api-design/SKILL.md` and `skills/error-handling/SKILL.md` — the HTTP surface
+
+Where an ECC rule and [`architecture.md`](./architecture.md) disagree,
+`architecture.md` wins — it is normative for this repository — and the
+disagreement belongs in the carve-out list below rather than being resolved
+silently in either direction.
+
+A conformance pass over `lib/**` in August 2026 measured the package against
+those documents: **51 ECC rules were confirmed satisfied**, and the deviations
+that survived adversarial verification are filed in
+[`technical-debt-report.md`](./technical-debt-report.md).
+
+### Carve-outs — ECC rules that do not apply to `lib/**`
+
+`lib/` is a library imported into someone else's NestJS application. Several
+ECC rules assume a standalone application that owns its own `main.ts`. These
+four are formally not applicable **to `lib/**` only** — `demo/src/**` is a real
+application and follows the ECC rules as written.
+
+**Project structure.** ECC's NestJS project-structure template (`src/main.ts`,
+`src/app.module.ts`, `src/common/{filters,guards,interceptors,pipes}`,
+`src/config/`, `src/modules/<feature>/{dto,entities}`) does not apply to
+`lib/**`: it describes an application that owns its process and its Nest request
+pipeline, whereas `nest-graph-inspector` is a single-entry-module published
+library laid out as ports and adapters. The template's transferable intents —
+domain code inside the module, types beside the code that owns them, one
+auditable composition root — remain binding and are already satisfied by that
+layout.
+
+**Global bootstrap registrations.** ECC's "bootstrap with a single global
+`ValidationPipe`, `ClassSerializerInterceptor`, and `useGlobalFilters(...)`"
+cannot be adopted: this package has no bootstrap and must not acquire one.
+Registering a global pipe or filter from a library would change how the *host's
+own controllers* behave, which a diagnostic tool has no right to do.
+
+**Response DTOs for Direct Run.** ECC's "use dedicated response DTOs or
+serializers instead of returning ORM entities directly" does not apply to the
+return value of `POST /direct-run` or the `/direct-run/history*` routes: the
+endpoint exists to return whatever the invoked host provider method returned, so
+the open `result` field is the feature rather than a leak, and the rule's
+stable-contract obligation is discharged by the `DirectRunResult` envelope that
+wraps it. The adjacent obligation to avoid leaking internal fields is **not**
+carved out and continues to bind wherever the library retains that value,
+re-serves it to a later caller, or writes it to disk.
+
+**Resource naming and URL versioning.** ECC's plural-collection-noun and
+`/api/v1/` rules do not apply to the inspector route table: those paths are a
+versioned cross-package contract between `lib/` and the viewer in `site/`,
+parsed out of the printed startup line under invariant 9 and asserted literally
+in `site/app/utils/inspector-endpoint-url.test.ts`, and the API is already
+versioned by `GRAPH_OUTPUT_SCHEMA_VERSION` against the viewer's
+`MINIMUM_SUPPORTED_GRAPH_OUTPUT_VERSION`. What still binds: a **new** inspector
+route must match the conventions of the existing table rather than inventing a
+third style.
+
+### Mechanism substitutions — ECC's intent binds, its mechanism does not
+
+These are not exemptions. The rule's obligation applies in full; only the
+framework mechanism it prescribes is unavailable, and this is what replaces it.
+
+| ECC rule | Why the mechanism fails here | What discharges it instead |
+|---|---|---|
+| `@Catch()` exception filter registered with `useGlobalFilters` | Needs an Express `Response` via `ArgumentsHost`; invariant 6 keeps the inspector on plain `node:http` | The single catch in `HttpServeAdapter.handleRequest` **is** this library's exception filter. It must answer the same JSON `{ ok: false, error }` envelope as every other route, return a generic message, and log the real error. Today it does none of these — see TD-24. |
+| `@UseGuards(...)` / `CanActivate` / `@Roles` | Same — no Nest request pipeline | A `HttpServeAuthorize` function registered through `register({ authorize: accessTokenService.createHttpGuard() }, …)`. The rule's request-context half still binds: that function must return the verified `AccessTokenPayload` and the router must expose it to route callbacks, so a Direct Run audit line can attribute an invocation. |
+| Validate every request DTO with `class-validator`; enable `whitelist` / `forbidNonWhitelisted` | No `ValidationPipe` ever runs, and `class-validator` is not a dependency of `lib/` | Hand-written validation in the adapter, with the same two guarantees: reject any key outside `['module','provider','method','args']` with a 400, and validate `args` against the `parameterTypes` the library already computes. Do not add a DTO class. |
+| Terminate on invalid env/config instead of booting partially | A library must never abort a host's boot because port 53371 was taken | Terminate the affected **capability**, not the process. Output-adapter failures stay logged and swallowed. Security-relevant misconfiguration does not: a secret shorter than the documented 32-character minimum must stop being used, not merely warn. |
+| Use-case code must not import framework types | The NestJS container is this library's subject matter and its lifecycle is the inbound adapter's trigger | `@Injectable()` and `OnModuleInit` on `NestGraphInspectorSetup` are exempt. The rule still binds to the graph-building logic inside it — cycle detection and type rendering import only `lib/src/types/**`. See TD-02. |
+| Fail fast and loudly | An output failure reaching the host would abort its boot | The failure must still reach *someone who can act*, and for a library that is the importing application. An optional `onOutputError` hook, defaulting to a no-op, satisfies ECC without changing the default. |
+
+### Where ECC does not reach
+
+Adopting a ready-made standard buys consistency, not coverage. The August 2026
+pass produced one clear example, and it is worth knowing before treating ECC
+conformance as sufficient.
+
+The most dangerous latent defect found in `lib/**` — TD-08, where bumping
+`GRAPH_OUTPUT_SCHEMA_VERSION` silently fails to change the emitted graph while
+every test still passes — was raised by the conformance pass and then
+**correctly refuted** as an ECC finding. ECC's "HIGH — Type Safety" block
+contains exactly four bullets (`any`, non-null assertions, unsafe `as` casts,
+relaxed compiler settings) and none of them requires a contract field with one
+known value to be typed as a literal. The verifier's conclusion was that the fix
+"would be a genuine improvement — but it is a design suggestion, not an instance
+of any ECC rule."
+
+That is the correct call about ECC and the wrong outcome for this repository.
+Two practical consequences:
+
+1. **A clean ECC pass is a floor, not a verdict.** Contract-integrity questions —
+   can the type system catch a version drift, can a test detect one — sit
+   outside the rubric and need their own review.
+2. **When a refuted finding is still real, file it on its own evidence** rather
+   than dropping it because no rule covers it. TD-08 is filed that way, and
+   this section is why.
+
+If a rule this project needs turns out to be missing from ECC repeatedly, the
+answer is a short project-specific supplement here — not a fork of ECC, and not
+silence.
+
+### Running a review
+
+```bash
+pnpm run verify   # lint + typecheck + test + build, across the workspace
+```
+
+`verify` does **not** run the demo's e2e suites. Any change to the access token,
+the CORS policy, the bind interface, or the Direct Run surface additionally
+requires a case in `demo/test/graph-inspector-security.e2e-spec.ts` and:
+
+```bash
+pnpm --filter nest-graph-inspector-demo run test:e2e
+```

--- a/docs/technical-debt-report.md
+++ b/docs/technical-debt-report.md
@@ -1,489 +1,456 @@
 # Technical Debt Report
 
-**Scope:** Current repository implementation, configuration, tests, and documentation.  
-**Method:** Findings below are backed by files present in the repository. This report does not infer roadmap intent.
+**Scope:** `lib/**` (the published npm package). `demo/**` and `site/**` were not
+audited in this pass except where a `lib/` contract reaches them.
+**Last revalidated:** 2026-08-31.
+**Method:** Every finding below was read at the cited file and line. Findings
+inherited from the previous edition of this report were re-checked against
+current code rather than carried forward. Findings measured against the ECC
+coding standards were additionally put through an adversarial refutation pass;
+40% of the candidates (25 of 62) did not survive it and are not listed here.
+
+> **How to read this document.** A finding's presence means the deviation was
+> confirmed in code. It does not mean the deviation is wrong: `docs/architecture.md`
+> is normative, and where it documents a decision deliberately, this report says
+> so instead of demanding a change.
+
+---
+
+## What changed since the previous edition
+
+The previous edition described a codebase without access control, without CI,
+and with a site that reached into library internals. None of that is true now.
+Four of its thirteen findings are fully resolved and its one Critical is
+obsolete.
+
+| ID | Previous claim | Status | Evidence |
+|---|---|---|---|
+| TD-01 | Default viewer exposes **unauthenticated** Direct Run | **Obsolete** | `AccessTokenService.createHttpGuard()` is attached at `viewer-output.adapter.ts:60` and `http-output.adapter.ts:70`; `http-serve.adapter.ts:75-76` propagates it to any route lacking one; `enabled` defaults to `true`. An anonymous `POST /direct-run` returns 401 — asserted in `demo/test/graph-inspector-security.e2e-spec.ts:154`. |
+| TD-02 | `NestGraphInspectorSetup` is 1,619 lines | **Revised** → TD-02 below | Now 1,166 lines. The size claim shrank; the cohesion claim survived and is now evidenced. |
+| TD-03 | Site imports library types from internal source paths | **Resolved** | No `nest-graph-inspector/src` import remains anywhere in `site/`; all imports go through the package entry point. |
+| TD-04 | The only e2e test is a stale Nest scaffold | **Resolved** | `demo/test/` holds `app.e2e-spec.ts` and `graph-inspector-security.e2e-spec.ts`; no scaffold remains. |
+| TD-05 | No CI runs library tests, lint, typecheck, or build | **Resolved** | `.github/workflows/ci.yml` runs a `verify` job, a `library-matrix` job on Node 20/22/24, and a full site build including the payload boot check. |
+| TD-06 | Adding an output type requires four coordinated edits | **Unchanged** | Still four files. Documented as an extension-point cost in `architecture.md`. |
+| TD-07 | Direct Run crosses the config boundary via casts | **Narrowed** → TD-07 below | The body-parsing casts improved; one intersection cast remains. |
+| TD-08 | Schema version duplicated as literal and constant | **Relocated and worse** → TD-08 below | The duplication the report named is fixed; a more dangerous one replaced it. |
+| TD-09 | CORS and path normalization duplicated across adapters | **Partly resolved** → TD-09 below | The `normalizePath` triplication was refuted as a real defect; the CORS duplication stands. |
+| TD-10 | Provider and module cycles use incompatible path shapes | **Unchanged** | Still asymmetric; acknowledged in `architecture.md`. |
+| TD-11 | User-facing documentation is stale | **Partly resolved** → TD-11 below | The README no longer calls Direct Run "coming soon"; `site/content/2.configuration/4.access-token.md` now exists. Two claims in `outputs.md` remain wrong. |
+| TD-12 | Documentation ownership overlaps three directories | **Weakened** | `demo/docs/` is now three files (`index.html`, `diagram.html`, `logo.png`) and no longer a competing Markdown surface. Downgraded to Low. |
+| TD-14 | `site/README.md` is the Nuxt template README | **Unchanged** | Still opens "# Nuxt Docs Template". |
+
+There is no TD-13; the previous edition skipped the number.
+
+---
 
 ## Priority summary
 
-| Priority | Finding | Category |
+| Priority | ID | Finding |
 |---|---|---|
-| Critical | Default viewer exposes unauthenticated Direct Run over a wildcard-CORS HTTP server | Architectural risk |
-| High | `NestGraphInspectorSetup` is a 1,619-line orchestration and domain-logic class | Maintainability / extension risk |
-| High | Site consumes library types through internal source paths instead of the library public entry point | Architectural boundary risk |
-| High | The library e2e test is a stale Nest scaffold and does not test a route the demo app provides | Test reliability |
-| High | No CI job runs library tests, linting, type checking, or package build | Validation gap |
-| Medium | Output extension is closed over a union, core dispatch record, DI registration, and internal-only port | Difficult-to-extend API |
-| Medium | Direct Run uses internal-only configuration injected through type intersections and casts | Difficult-to-extend API |
-| Medium | Graph schema version is duplicated as a literal and as the schema constant | Duplicated implementation |
-| Medium | URL/path normalization is implemented independently in two adapters | Duplicated implementation |
-| Medium | Graph cycle serialization is inconsistent between provider and controller cycles | Inconsistent contract / naming |
-| Medium | Documentation gives conflicting status and shape descriptions for implemented features | Missing / stale documentation |
-| Medium | `demo/docs/` and `site/content/` overlap as documentation surfaces | Overlapping directories / unclear ownership |
-| Low | `site/README.md` remains the Nuxt Docs Template README | Stale documentation |
+| Critical | TD-15 | Any unauthenticated client can terminate the host process with one malformed request line |
+| Critical | TD-16 | A discovery failure crashes the host application whenever a non-viewer output is configured |
+| High | TD-17 | A history-write failure reports a successful Direct Run invocation as a 500 |
+| High | TD-18 | Trace history, request bodies, and stored arguments are all unbounded |
+| High | TD-19 | An unsettled promise in a traced call hangs the request forever |
+| High | TD-20 | `defaultOptions` is a mutable singleton wired straight into DI and exported publicly |
+| Medium | TD-08 | A schema-version bump silently does not reach the emitted graph, and no test fails |
+| Medium | TD-21 | Direct Run reaches `constructor`, inherited methods, and getters it never advertises |
+| Medium | TD-22 | Discovery silently drops dependencies and providers it cannot name |
+| Medium | TD-23 | The Markdown output ignores the configured `nestCoreModuleName` |
+| Medium | TD-24 | The router returns raw internal error messages and logs nothing |
+| Medium | TD-25 | ts-morph parsing blocks the host's event loop inside a request handler |
+| Medium | TD-02 | ~63% of `NestGraphInspectorSetup` is framework-free logic trapped in a DI class |
+| Medium | TD-06 | Adding an output type requires four coordinated edits |
+| Medium | TD-07 | An intersection cast smuggles internal config through a public options type |
+| Medium | TD-10 | Provider and module cycles use incompatible path representations |
+| Low | TD-09 | Path normalization is split across two adapters that must agree |
+| Low | TD-11 | Two claims on the outputs documentation page contradict the code |
+| Low | TD-12 | `demo/docs/` and `site/content/` still overlap as documentation surfaces |
+| Low | TD-14 | `site/README.md` is still the Nuxt Docs Template README |
+| Low | TD-26 | Four methods in `lib/src` are dead code |
+| Low | TD-27 | The package has no formatter, and formatting has diverged |
 
 ---
 
 ## Critical
 
-### TD-01 — Default viewer enables unauthenticated Direct Run on a wildcard-CORS server
+### TD-15 — One malformed request line terminates the host process, with no token
 
-**Evidence**
+**Evidence.** Three properties combine, all in `lib/src/adapters/http-serve.adapter.ts`:
 
-- `lib/src/nest-graph-inspector.module.ts` makes
-  `viewer` the default output, and its default viewer configuration includes
-  `directRun: { path: '/direct-run' }`.
-- The same default viewer configuration spreads `HttpOutputAdapter.defaultConfig`,
-  whose host is `0.0.0.0` and port is `53371`.
-- `lib/src/adapters/viewer-output.adapter.ts` registers
-  Direct Run routes whenever the internal `directRun.path` is set.
-- `lib/src/adapters/direct-run-output.adapter.ts`
-  accepts a request body containing `module`, `provider`, `method`, and `args`,
-  resolves the provider instance, then calls `method.call(instance, ...args)`.
-  Its checks validate only required fields, provider availability, method existence,
-  and argument count/shape.
-- `lib/src/adapters/http-serve.adapter.ts` applies
-  `Access-Control-Allow-Origin: *`, broad methods, and `Access-Control-Allow-Headers: *`
-  to every request before routing. The Direct Run route has no separate access
-  control.
+- `:156` — the server handler is invoked as `void this.handleRequest(...)`, with no `.catch()`.
+- `:190` — `this.route(originUrl, routes, req)` runs **before** the authorization check at `:206` and **outside** the `try` that opens at `:216`.
+- `:244` — `route()` builds the path with `new URL(req.url ?? '/', originUrl)` over the raw, unvalidated request target.
 
-**Impact**
+**Reproduced.** A standalone replica of this exact path, driven over a TCP
+socket with the request line `GET http://[invalid HTTP/1.1` and **no
+credentials**, produced `UNHANDLED_REJECTION: ERR_INVALID_URL` and exited
+non-zero on Node v24.19.0. Node's parser accepts the absolute-form target
+verbatim, `new URL` rejects the unterminated IPv6 literal, and the rejection has
+no handler.
 
-Starting the module with its default output creates an HTTP endpoint capable of
-executing discovered provider methods. The current implementation has no
-authentication, authorization, provider allowlist, method allowlist, or origin
-restriction around that endpoint. Because the server uses `0.0.0.0` by default
-and publishes wildcard CORS headers, network and browser exposure must be treated
-as part of the default behavior.
+**Impact.** The whole host NestJS application dies, not just the inspector.
+Because the throw precedes `route.authorize?.(req)`, the access token — the
+control that `architecture.md` names as what makes the wide-open bind and CORS
+policy safe — never runs. With the default bind of `0.0.0.0`, this is reachable
+from the local network.
 
-**Why this is debt**
+**Why this is debt.** `architecture.md`'s "Known deliberate risks" table accepts
+network reachability *on the basis that the token protects it*. An
+unauthenticated crash is outside that bargain and is not listed anywhere.
 
-The feature is enabled by default, while its safety boundary is entirely implicit
-in deployment topology. The user-facing README still calls Direct Run “coming
-soon,” so the behavior is not clearly communicated to users.
+**Fix direction.** Wrap `handleRequest` so nothing escapes it — either a
+top-level `try/catch` answering 400, or a `.catch()` on the `void` call — and
+guard the `new URL` construction in `route()`. Per invariant 7, add a case to
+`demo/test/graph-inspector-security.e2e-spec.ts` and run
+`pnpm --filter nest-graph-inspector-demo run test:e2e` yourself; CI does not.
 
-**Related code**
+---
 
-- `lib/src/nest-graph-inspector.module.ts`
-- `lib/src/adapters/viewer-output.adapter.ts`
-- `lib/src/adapters/direct-run-output.adapter.ts`
-- `lib/src/adapters/http-serve.adapter.ts`
+### TD-16 — A discovery failure crashes the host whenever a non-viewer output is configured
+
+**Evidence.** `lib/src/nest-graph-inspector.setup.ts:119-124`:
+
+```ts
+if (eagerOutputs.length) {
+  await this.publishOutputs({
+    graphOutput: this.getGraphOutput(),   // evaluated here, outside any try/catch
+    outputs: eagerOutputs,
+  });
+}
+```
+
+`getGraphOutput()` is an argument, so it is evaluated before `publishOutputs`
+runs. The `try/catch` that `architecture.md` promises ("A failing output never
+fails the application") lives one level deeper, in `publishSingleOutput`
+(`:174-190`), and never covers discovery. `discovery.scan()` can throw — "Root
+module not found", or a `SourceMetadataService` failure on a malformed
+`tsconfig.json` — and the rejection leaves `onModuleInit`, which Nest treats as
+a fatal bootstrap error.
+
+**Impact.** The asymmetry is the dangerous part. A viewer-only configuration is
+safe, because discovery is deferred into a route resolver that runs inside the
+router's `try/catch` and degrades to a 500. Add one `json`, `markdown`, or
+`http` output and the identical failure becomes a boot crash. Nothing documents
+this difference.
+
+**Fix direction.** Bring the first `getGraphOutput()` evaluation under the same
+catch discipline as `publishSingleOutput`, so `onModuleInit` resolves with a
+logged error whichever output type is configured.
 
 ---
 
 ## High
 
-### TD-02 — `NestGraphInspectorSetup` combines seven responsibilities in one 1,619-line class
+### TD-17 — A history-write failure turns a successful invocation into a 500
 
-**Evidence**
+**Evidence.** `lib/src/adapters/direct-run-output.adapter.ts:68-114` computes the
+real `DirectRunResult` first, then calls `onComplete(payload.runtimeTrace)`
+unguarded before returning. `onComplete` is `writeHistoryFiles`
+(`viewer-output.adapter.ts:139-162`), which does a `mkdir` and two `writeFile`s.
+A rejection there propagates into the router's catch and answers 500.
 
-`lib/src/nest-graph-inspector.setup.ts` is 1,619
-lines and currently performs all of the following:
+**Impact.** The provider method already ran and may already have mutated state.
+The caller is told it failed. For a tool whose purpose is invoking real service
+methods, an operator seeing that 500 may retry a side effect that already
+applied. This does not hide a failure — it manufactures one on top of a success.
 
-1. NestJS root-module discovery through `ModulesContainer`.
-2. Module-tree construction and flattening.
-3. Provider, controller, import, export, and injection-token extraction.
-4. Source lookup and JSDoc extraction using ts-morph.
-5. Runtime mutation/instrumentation of provider and controller instances for tracing.
-6. Direct Run method metadata extraction and TypeScript type-string rendering.
-7. `ModuleMap` → `GraphOutput` enrichment and graph-cycle detection.
-8. Output defaulting, adapter selection, dispatch, and logging.
+**Fix direction.** Catch `onComplete` separately, keep the computed payload, and
+signal persistence failure as a separate field rather than by changing `ok`.
 
-It directly imports NestJS internals, ts-morph, every output adapter, the output
-port, the runtime recorder, intermediate graph types, and final graph types.
+### TD-18 — Trace history, request bodies, and stored arguments are all unbounded
 
-**Impact**
+**Evidence.** Three independent missing bounds:
 
-Changes to extraction, trace instrumentation, Direct Run metadata, graph
-serialization, cycle detection, or output dispatch are all concentrated in one
-class. Tests must construct it with a large dependency set, and unrelated changes
-risk conflicting in the same file.
+- `runtime-trace.recorder.ts:31` — `completedTraces` is a `Map` that is never evicted.
+- `direct-run-output.adapter.ts:170-188` — `readJsonBody` accumulates the entire request body into one string with no size cap and no `content-length` check.
+- `runtime-trace.recorder.ts:422-433` — `previewValue` checks serializability but does not truncate, so arguments and return values are stored verbatim.
 
-**Why this is debt**
+**Impact.** An authenticated caller can exhaust host memory, and `GET
+/direct-run/histories` returns the whole collection in one response with no
+pagination. When a `json` output is configured the same unbounded values are
+also written to disk.
 
-The existing adapter layer separates output mechanics, but equivalent boundaries
-are absent for extraction, enrichment, trace instrumentation, and cycle analysis.
-The file is already substantially larger than any other library source module.
+**Why this is debt rather than an accepted risk.** The repository already
+solved this exact problem one file away: `access-attempt-limiter.ts` caps
+`maxTrackedClients` at 1,000 explicitly "so the tracker cannot itself be grown
+without limit". The pattern exists and was not applied here.
 
-**Related code**
+### TD-19 — An unsettled promise in a traced call hangs the request forever
 
-- `lib/src/nest-graph-inspector.setup.ts`
-- `lib/src/nest-graph-inspector.setup.spec.ts`
+**Evidence.** `runtime-trace.recorder.ts:172-241` — `finishTrace` calls
+`markPendingSpansNotAwaited` and then `await this.waitForPendingSpans(traceId)`,
+a `Promise.all` with no timeout and no race.
+`direct-run-output.adapter.ts:76-79` awaits that before responding.
 
----
+**Impact.** A fire-and-forget call inside a traced method that never settles —
+a write to an unreachable service, say — leaves `POST /direct-run` with no
+response and no log line. The `partial` status exists precisely to handle
+un-awaited promises, but it only covers promises that eventually settle.
 
-### TD-03 — The site bypasses the package public API and imports library types from internal source paths
+**Fix direction.** Bound `waitForPendingSpans`, reusing the timeout pattern
+already established by `LATEST_VERSION_TIMEOUT_MS`, so the trace still completes
+and reports `partial`.
 
-**Evidence**
+### TD-20 — `defaultOptions` is a mutable singleton wired into DI and exported publicly
 
-`site/nuxt.config.ts` defines `@library` as an alias to `../library`, then site
-files import types with paths such as:
+**Evidence.** `nest-graph-inspector.module.ts:19-39` declares `defaultOptions`
+as a plain object — no `as const`, no `Object.freeze`, no `Readonly<>`. The same
+object instance is the literal `useValue` for `MODULE_OPTIONS_TOKEN` (`:45`)
+and is re-exported from `lib/src/index.ts`.
 
-```ts
-@lib/src/types/graph-output.type
-@lib/src/types/direct-run.type
-```
-
-Current uses include:
-
-- `site/app/stores/graph-inspector.ts`
-- `site/app/utils/circular-dependency-issues.ts`
-- `site/app/utils/direct-run-provider.ts`
-- `site/app/components/content/RuntimeGraphPreview.vue`
-- `site/app/components/content/RuntimeGraphDirectRunPreview.vue`
-
-The npm package itself exposes only `"."` in its `exports` map, and `index.ts`
-already re-exports both graph-output and direct-run types.
-
-**Impact**
-
-The site is coupled to the library's internal source layout
-(`libs/nest-graph-inspector/src/types/...`) rather than its declared public entry
-point. Moving a type file or tightening package/export boundaries can break the
-site even when the library's public API remains unchanged.
-
-**Why this is debt**
-
-This duplicates the ownership of the contract: the library claims a root public
-entry point, while the site treats source-file paths as a contract. The repository
-instructions say the frontend should integrate through the reusable library's
-public API; current imports do not do that.
-
-**Related code**
-
-- `site/nuxt.config.ts`
-- `lib/package.json`
-- `lib/src/index.ts`
-- Site files listed above
-
----
-
-### TD-04 — The only e2e test is a stale scaffold that does not match the demo application
-
-**Evidence**
-
-`demo/test/app.e2e-spec.ts` imports `AppModule`, starts a Nest app, then
-expects `GET /` to return `200` and `"Hello World!"`.
-
-A repository-wide search finds `"Hello World!"` only in that test. The demo app
-under `demo/src/` contains no root controller or endpoint that returns this
-response.
-
-**Impact**
-
-`pnpm test:e2e` does not validate the graph inspector's actual integration path
-and is expected to fail against the current application. This makes a documented
-validation command unreliable.
-
-**Related code**
-
-- `demo/test/app.e2e-spec.ts`
-- `demo/test/jest-e2e.json`
-- `demo/src/app.module.ts`
-
----
-
-### TD-05 — CI deploys the site but does not validate the reusable library
-
-**Evidence**
-
-`.github/workflows/deploy-site.yml` is the only workflow. It installs dependencies
-and runs `pnpm exec nuxt generate` in `site/`, then deploys GitHub Pages.
-
-The reusable package provides `pnpm build` and `pnpm test` in `lib/package.json`.
-The demo host provides `pnpm build`, `pnpm lint`, `pnpm test`, and
-`pnpm test:e2e` in `demo/package.json`. No GitHub Actions workflow runs them.
-The workflow also does not run `site` linting or type checking.
-
-**Impact**
-
-A change can be merged and deployed while library unit tests, library build,
-library linting, site linting, site type checking, and e2e tests are not executed
-by CI.
-
-**Related files**
-
-- `.github/workflows/deploy-site.yml`
-- `lib/package.json`
-- `demo/package.json`
-- `site/package.json`
+**Impact.** Any consumer or test that imports it and mutates a nested field —
+`defaultOptions.outputs[0].port = 9999`, `defaultOptions.ignoreProvider.push(...)` —
+changes the running configuration for every other inspector instance in the
+process. Multiple modules booted in one Jest worker is the ordinary way to hit
+this.
 
 ---
 
 ## Medium
 
-### TD-06 — Adding an output type requires core changes in several unrelated locations
-
-**Evidence**
-
-Current outputs are represented by the closed `NestGraphInspectorOutput`
-discriminated union in `nest-graph-inspector.type.ts`. To add a new output type,
-the implementation must modify at least:
-
-1. The `NestGraphInspectorOutput` union.
-2. The `Record<NestGraphInspectorOutput['type'], OutputAdapter>` construction in
-   `NestGraphInspectorSetup`.
-3. `NestGraphInspectorModule` provider registration.
-4. The `outputAdapters` map wiring in the setup-service constructor.
-5. Tests and user-facing configuration documentation.
-
-`OutputAdapter<Config>` exists in `src/ports/output.adapter.ts`, but it is not
-re-exported from `index.ts`; therefore it is not a documented extension point for
-library consumers.
-
-**Impact**
-
-The adapter abstraction is only partially extensible: it abstracts built-in output
-implementations but does not provide a supported registration mechanism for new
-output types. Every extension changes central library code and public union types.
-
-**Related code**
-
-- `lib/src/nest-graph-inspector.type.ts`
-- `lib/src/nest-graph-inspector.setup.ts`
-- `lib/src/nest-graph-inspector.module.ts`
-- `lib/src/ports/output.adapter.ts`
-
----
-
-### TD-07 — Direct Run crosses the public/internal configuration boundary through type widening and casts
-
-**Evidence**
-
-The public viewer configuration exposes only:
-
-```ts
-type NestGraphInspectorViewerDirectRunOptions = { path?: string }
-```
-
-`NestGraphInspectorSetup.mergeViewerDirectRunOptions()` adds two internal values:
-`historyDirPath` and `instanceLookup`. `ViewerOutputAdapter` then defines a
-separate `ViewerOutputInternalConfig` type and casts its public
-`ViewerOutputConfig` parameter to that type:
-
-```ts
-const internalConfig = config as ViewerOutputInternalConfig;
-```
-
-`HttpOutputAdapter` uses the same pattern with `HttpOutputInternalOptions`, adding
-an internal `httpAdapter` field to its public `http` output configuration type.
-
-**Impact**
-
-The public output configuration is not the actual configuration the adapters
-consume. Internal capabilities are transported through structural intersections
-and casts, making the flow harder to type-check, harder to reuse, and difficult
-for an external adapter or alternate Direct Run implementation to extend.
-
-**Related code**
-
-- `lib/src/nest-graph-inspector.setup.ts`
-- `lib/src/adapters/viewer-output.adapter.ts`
-- `lib/src/adapters/http-output.adapter.ts`
-- `lib/src/nest-graph-inspector.type.ts`
-
----
-
-### TD-08 — Graph schema version is duplicated instead of sourced from the schema constant
-
-**Evidence**
-
-- `lib/src/types/graph-output.schema.ts` exports
-  `GRAPH_OUTPUT_SCHEMA_VERSION = '3'`.
-- `lib/src/nest-graph-inspector.setup.ts` returns
-  `version: '3'` directly in `createModuleMapFromModuleTree()`.
-
-**Impact**
-
-A schema-version update can change the schema constant while leaving generated
-output on the old version, or vice versa. No shared source enforces that the two
-values remain aligned.
-
-**Related code**
-
-- `lib/src/types/graph-output.schema.ts`
-- `lib/src/nest-graph-inspector.setup.ts`
-
----
-
-### TD-09 — Path normalization is implemented independently in two adapters
-
-**Evidence**
-
-Path/origin normalization:
-
-- `HttpOutputAdapter.normalizePath()`.
-- `HttpServeAdapter.normalizePath()` and `normalizeOrigin()`.
-
-The implementations do not have identical policy: `HttpOutputAdapter` leaves a
-trailing slash, while `HttpServeAdapter` normalizes only a leading slash (except
-`'*'`). `HttpOutputAdapter` computes the path a route is advertised under and
-`HttpServeAdapter` computes the key that path is matched by, so the two have to
-agree for a route to be reachable at the URL the viewer was given.
-
-CORS is no longer duplicated: `HttpServeAdapter` is now the only component that
-sets CORS headers or answers a preflight, since the request-forwarding adapter
-that carried the second implementation was deleted with the in-browser AI chat
-change.
-
-**Impact**
-
-Path handling can change in one adapter without the other, producing a route that
-is registered under one spelling and advertised under another. The remaining
-wildcard CORS policy is covered by TD-01.
-
-**Related code**
-
-- `lib/src/adapters/http-serve.adapter.ts`
-- `lib/src/adapters/http-output.adapter.ts`
-
----
-
-### TD-10 — Cycle data uses two incompatible path representations for the same dependency-domain concept
-
-**Evidence**
-
-`GraphOutputCycles` declares:
-
-```ts
-type GraphOutputCycles = {
-  modules: GraphOutputCycle[];           // path: string[]
-  providers: GraphOutputProviderCycle[]; // path: { module, provider }[]
-  controllers: GraphOutputCycle[];       // path: string[]
-}
-```
-
-In `NestGraphInspectorSetup.findDependencyCycles()`, provider cycles are converted
-through `toProviderCycle()` into structured path items. Controller cycles are
-returned as the original `GraphOutputCycle`, whose path contains composite strings
-such as `"ModuleName:ControllerName"`.
-
-The site must maintain separate formatting paths in
-`site/app/utils/circular-dependency-issues.ts`: `formatProviderCyclePath()` for
-provider cycles and `formatDependencyCyclePath()` for controller cycles.
-
-**Impact**
-
-Consumers cannot use one traversal/rendering strategy for all dependency cycles.
-Adding another node category or altering identifiers requires category-specific
-code in both producer and consumer. This inconsistency is already documented as
-an open question in `docs/graph-contract.md`.
-
-**Related code**
-
-- `lib/src/types/graph-output.type.ts`
-- `lib/src/nest-graph-inspector.setup.ts`
-- `site/app/utils/circular-dependency-issues.ts`
-
----
-
-### TD-11 — User-facing documentation is stale or conflicts with current implementation
-
-**Evidence**
-
-1. The root `README.md` calls **Direct Run** “coming soon.”
-   The repository currently implements Direct Run endpoint registration, provider
-   invocation, trace recording, persisted histories, and viewer UI, and the
-   documentation site demonstrates all of it against a running application.
-
-2. `site/content/2.configuration/2.outputs.md` describes JSON output as “the raw
-   module map.” `JsonOutputAdapter.execute()` serializes `GraphOutput`, which is
-   an enriched format containing `GraphOutputDependencyRef` objects, `cycles`, and
-   optional `directRun` metadata. The intermediate raw `ModuleMap` is not written
-   by that adapter.
-
-3. The same outputs page calls JSON a “stable data artifact,” while its warning at
-   the top says output formats beyond the Web Viewer are under active iteration
-   and “format-level breaking changes may land between releases.”
-
-4. `NestGraphInspectorViewerDirectRunOptions`, `DirectRunResult`, runtime trace
-   types, the schema import use case, and Direct Run security/exposure behavior
-   have no dedicated user-facing documentation.
-
-**Impact**
-
-Consumers may make configuration and security decisions from documentation that
-does not describe what the package currently does or writes.
-
-**Related files**
-
-- `README.md`
-- `site/content/2.configuration/2.outputs.md`
-- `lib/src/adapters/json-output.adapter.ts`
-- `lib/src/adapters/direct-run-output.adapter.ts`
-- `lib/src/types/direct-run.type.ts`
-
----
-
-### TD-12 — Documentation ownership overlaps across `docs/`, `site/content/`, and `demo/docs/`
-
-**Evidence**
-
-- Root `docs/` contains contributor/maintainer documents such as architecture,
-  graph contract, development guidelines, maintainers guide, public API, and this
-  report.
-- `site/content/` contains user-facing MDC docs for installation, configuration,
-  and internals; it is rendered and deployed through Nuxt.
-- `demo/docs/` contains standalone static HTML files (`index.html`,
-  `diagram.html`, `logo.png`) that describe the same project. No current script
-  was found that generates or deploys those files.
-
-**Impact**
-
-There are three documentation locations with partially overlapping technical
-scope. A change to configuration, graph behavior, or public API has no single
-obvious documentation source of truth.
-
-**Related directories**
-
-- `docs/`
-- `site/content/`
-- `demo/docs/`
+### TD-08 — A schema-version bump silently does not reach the emitted graph
+
+**This finding replaces the previous TD-08, which is fixed.** The literal-versus-constant
+duplication it described is gone: `graph-output.schema.ts:12` now reads
+`const: GRAPH_OUTPUT_SCHEMA_VERSION`. The duplication moved somewhere worse.
+
+**Evidence.** The version exists in five places, three of them hardcoded:
+
+| Location | Form | Derived from the constant? |
+|---|---|---|
+| `types/graph-output.schema.ts:1` | `GRAPH_OUTPUT_SCHEMA_VERSION = '3'` | source of truth |
+| `types/graph-output.schema.ts:12` | `const: GRAPH_OUTPUT_SCHEMA_VERSION` | yes |
+| `types/graph-output.schema.ts:5` | `$id: '…/graph-output-v3.schema.json'` | **no** |
+| `nest-graph-inspector.setup.ts:275` | `version: "3"` | **no** — and the file never imports the constant |
+| `nest-graph-inspector.setup.spec.ts:161,242` | asserts `version: "3"` | **no** |
+
+`types/graph-output.type.ts:58` types the field as the wide primitive `string`,
+so the compiler cannot relate the two either.
+
+**Impact.** Following the bump procedure that `architecture.md` documents —
+raise `GRAPH_OUTPUT_SCHEMA_VERSION` — changes the JSON Schema but leaves the
+emitted graph announcing `"3"` and `$id` pointing at `v3`. **Every test still
+passes**, because the specs assert the same literal the emitter still produces.
+The viewer receives a v4 graph claiming to be v3 and renders it. The documented
+upgrade path silently does not work, and the version gate that exists to make a
+half-done bump visible is what fails first.
+
+**Fix direction.** Import the constant in `setup.ts`, derive `$id` from it, and
+narrow the contract type to `version: typeof GRAPH_OUTPUT_SCHEMA_VERSION` so the
+compiler catches the next drift instead of a reviewer.
+
+**Note on standards coverage.** The ECC conformance pass raised this and its own
+adversarial verifier **correctly refuted it** — ECC's "HIGH — Type Safety" block
+has exactly four bullets and none of them requires a literal type for a contract
+field. The verifier's own words: it "would be a genuine improvement — but it is
+a design suggestion, not an instance of any ECC rule." The finding is kept here
+on its own evidence. See [`development-guidelines.md`](./development-guidelines.md#where-ecc-does-not-reach)
+for what this implies about relying on ECC alone.
+
+### TD-21 — Direct Run reaches methods it never advertises
+
+**Evidence.** The advertised list is built in `nest-graph-inspector.setup.ts:393-436`,
+which walks one prototype level, excludes `constructor`, and reads
+`descriptor.value`. The invocation path,
+`direct-run-output.adapter.ts:37-52`, does a plain `instance[methodName]` with
+no allowlist.
+
+Two consequences, both requiring a valid token:
+
+- `"method": "constructor"` re-runs the constructor body against the live singleton with attacker-supplied arguments, corrupting shared state for every other consumer in the process. Inherited base-class methods and `Object.prototype` builtins are reachable the same way.
+- Reading `instance[methodName]` **invokes a getter** before the `typeof method !== 'function'` check rejects it, so a getter's side effect runs even on a request that ends in 400. The metadata builder deliberately avoids this by reading `descriptor.value`; the invoker does not.
+
+Neither is covered by `demo/test/graph-inspector-security.e2e-spec.ts`.
+
+### TD-22 — Discovery silently drops dependencies and providers it cannot name
+
+**Evidence.** In `lib/src/adapters/discovery.ts`, three paths drop data with no
+signal: `extractDependencies` (`:510-559`) filters any resolved name equal to
+`"Object"`; `resolveDependencyName`/`tokenName` (`:571-608`, `:729-735`) return
+`null` for tokens that are not a non-empty string, symbol, or function; and
+`extractModuleMember` (`:454-474`) returns `null` — removing the whole provider
+or controller — when neither a class name nor a token name is available.
+
+**Impact.** This is the failure mode with the worst blast radius for this
+product specifically: the graph is not empty or broken, it is *plausible and
+wrong*. A dropped dependency vanishes from `dependencies`, from cycle detection,
+and from the Markdown report at once, and a reader has no reason to suspect it.
+Nothing logs, and nothing marks the emitted `GraphOutput`.
+
+**Fix direction.** Attach an `unresolved` marker to the emitted graph, or at
+minimum warn naming the module and class. Silence is the defect here, not the
+tolerance — the library should keep going, but not quietly.
+
+### TD-23 — The Markdown output ignores the configured `nestCoreModuleName`
+
+**Evidence.** `nestCoreModuleName` is a public option
+(`nest-graph-inspector.type.ts:173`). `DiscoveryAdapter` resolves it properly
+(`discovery.ts:55-57`) and uses it to name the virtual module (`:295`) and
+prefix tokens (`:357`, `:581`, `:706`). `FileOutputAdapter` declares its own
+hardcoded copy instead — `file-output.adapter.ts:26`,
+`private readonly nestCoreModuleName = 'NestJSCoreModule';` — and compares
+against it at `:132` and `:310`.
+
+**Impact.** A host configuring `nestCoreModuleName: 'FrameworkCore'` gets a
+graph whose virtual module carries that name and a Markdown report whose two
+guards never match: import arrows are drawn into the core module, and every
+real module's core-provider import is reported as an unused-import warning.
+
+### TD-24 — The router returns raw internal error messages and logs nothing
+
+**Evidence.** `http-serve.adapter.ts:230` answers
+`this.sendText(res, 500, err instanceof Error ? err.message : 'Error')`.
+A grep for `Logger` across that file returns nothing: the 508-line router that
+owns every 404 and 500 in the library has no logging at all.
+
+**Impact.** Both halves are inverted — the internal detail goes to the caller
+and nothing goes to the operator. The 500 also answers `text/plain` where every
+other route answers the JSON `{ ok: false, error }` envelope, so no client can
+parse inspector errors generically.
+
+### TD-25 — ts-morph parsing blocks the host's event loop inside a request handler
+
+**Evidence.** `source-metadata.service.ts:120-127` constructs
+`new Project({ tsConfigFilePath, skipAddingFilesFromTsConfig: false })` — CPU-bound
+TypeScript parsing of the host's whole source set — on the `GET /output.json`
+path under the default viewer configuration.
+
+**Nuance.** `architecture.md`'s deliberate-risk table documents the *deferral*
+("real startup cost … deferred to the first request"). It does not say the
+deferred work runs synchronously on the host's shared event loop. The deferral
+is right and stays; the synchronicity is an undocumented consequence of it, and
+the library charges it to a host whose users never opened the viewer.
+
+**Fix direction.** Move the scan off the request path — a `node:worker_threads`
+adapter behind the existing service (a Node builtin, so the single-runtime-dependency
+rule holds), or, as a smaller step, an opt-in warm-up that runs it on
+`setImmediate` after `onModuleInit` resolves. Either way, amend the
+deliberate-risk row to state that the deferred scan blocks the loop today.
+
+### TD-02 — Most of `NestGraphInspectorSetup` is framework-free logic trapped in a DI class
+
+**Evidence.** 1,166 lines, of which roughly 740 (~63%) have no structural need
+for the nine injected NestJS dependencies:
+
+| Block | Lines | Depends on injected services? |
+|---|---|---|
+| Output orchestration | ~97-244 | yes — this is the real use case |
+| Direct Run parameter extraction | ~397-541 | yes, via `sourceMetadata` |
+| TypeScript type-to-source renderer | ~543-850 (~300) | **no** — pure, recursive, argument-driven |
+| Graph cycle detection | ~852-1143 (~290) | **no** — operates on a `Map<string, Set<string>>` |
+
+**Measured cost, not a style opinion.** To unit-test the pure type renderer,
+`nest-graph-inspector.setup.spec.ts` must build a full `Test.createTestingModule`
+wiring five collaborators (`:105-120`) and define a `SetupWithPrivateMethods`
+cast (`:18-36`) to reach private methods. A function taking a ts-morph `Type` and
+returning a string should not need a mocked Nest container.
+
+**Fix direction.** Keep `@Injectable()` and `OnModuleInit` — the container is
+this library's subject matter and the lifecycle hook is the correct inbound
+adapter. Move the cycle detector and the type renderer into framework-free
+modules importing only `lib/src/types/**`, leaving the orchestrator around
+400-450 lines.
+
+### TD-07 — An intersection cast smuggles internal config through a public options type
+
+**Evidence.** `viewer-output.adapter.ts:14-19` declares
+`ViewerOutputInternalConfig = ViewerOutputConfig & { directRun?: { …; instanceLookup: … } }`
+and `:40` casts the incoming public config to it unchecked. The public
+`NestGraphInspectorViewerDirectRunOptions` declares only `{ path?: string }`.
+
+**Impact.** No live bug — the only caller populates it correctly. But nothing in
+the type system would catch a refactor that sets `directRun.path` and forgets
+`instanceLookup`; the failure would appear at request time as
+`instanceLookup is not a function`.
+
+### TD-06 — Adding an output type requires four coordinated edits
+
+Unchanged from the previous edition, and documented as an extension-point cost
+in `architecture.md`. Implement `OutputAdapter<Config>`, add the union variant,
+register the provider, and add it to the `outputAdapters` record.
+
+### TD-10 — Provider and module cycles use incompatible path representations
+
+Unchanged. Provider cycles carry `{ module, provider }` items; module and
+controller cycles carry plain name strings. Acknowledged in `architecture.md`.
 
 ---
 
 ## Low
 
-### TD-14 — `site/README.md` is still the uncustomized Nuxt Docs Template README
+### TD-09 — Path normalization is split across two adapters that must agree
 
-**Evidence**
+**Revised by the WebLLM change (`86c8e36`).** The previous edition of this
+finding also covered duplicated CORS preflight detection. That half is resolved:
+the request-forwarding adapter that carried the second implementation was
+deleted along with the Ollama proxy, so `HttpServeAdapter` is now the only
+component that sets CORS headers or answers a preflight.
 
-`site/README.md` identifies itself as “Nuxt Docs Template,” links to the template
-demo, and instructs users to run `npm create nuxt@latest -- -t ui/docs`. It does
-not describe Nest Graph Inspector's site, graph viewer, MCP tools, or local
-library integration.
+**Evidence.** Two `normalizePath` implementations remain, with different
+policies: `http-output.adapter.ts:55` leaves a trailing slash, while
+`http-serve.adapter.ts:501` normalizes only a leading slash (except `'*'`).
 
-**Impact**
+**Impact.** These are not interchangeable copies — which is why the "three
+duplicated implementations" framing was refuted — but they are coupled:
+`HttpOutputAdapter` computes the path a route is *advertised* under and
+`HttpServeAdapter` computes the key that path is *matched* by. If the two
+policies drift, a route is registered under one spelling and advertised under
+another, and the viewer receives a link it cannot reach.
 
-Contributors entering through `site/` receive misleading project-specific setup
-and ownership information.
+**Fix direction.** One shared definition of what a normalized inspector path is,
+used by both, rather than two private methods that happen to agree today.
 
-**Related files**
+---
 
-- `site/README.md`
-- `site/nuxt.config.ts`
-- `site/AGENTS.md`
+### TD-11 — Two claims on the outputs page contradict the code
+
+`site/content/2.configuration/2.outputs.md:73` calls the JSON output "the raw
+module map"; `JsonOutputAdapter` serializes the enriched `GraphOutput`. Line 79
+calls it "a stable data artifact" while the same page warns that format-level
+breaking changes may land between releases. Direct Run still has no dedicated
+documentation page.
+
+### TD-12 — `demo/docs/` and `site/content/` still overlap
+
+Downgraded from Medium: `demo/docs/` now holds three files, none of them
+Markdown, so the surfaces no longer compete for the same content.
+
+### TD-14 — `site/README.md` is still the Nuxt Docs Template README
+
+Unchanged. It opens "# Nuxt Docs Template" and instructs the reader to scaffold
+a new project.
+
+### TD-26 — Four methods in `lib/src` are dead
+
+No call site exists in `lib/`, `demo/`, `site/`, or any spec for
+`RuntimeTraceRecorder.classifyProviderType` (`:378`),
+`RuntimeTraceRecorder.summarizeValue` (`:405`, superseded by `previewValue`),
+`DiscoveryAdapter.extractImports` (`discovery.ts:375`), or
+`NestGraphInspectorSetup.buildModuleMapFromAutoDetect` (`setup.ts:242`).
+`tsconfig.base.json` sets `strict` but not `noUnusedLocals`, which is what would
+flag an unread private method.
+
+### TD-27 — No formatter, and formatting has diverged
+
+Six files use double-quoted strings against thirty-four using single quotes, and
+`recordSpan`'s try/catch body at `runtime-trace.recorder.ts:98` is un-indented.
+The package runs a linter but no formatter.
 
 ---
 
 ## Not classified as debt
 
-The following were inspected but are not reported as problems because the current
-repository provides a clear implementation-backed role:
+Inspected and deliberately excluded. The first four are unchanged from the
+previous edition; the rest were added by this pass.
 
-- `demo/src/` is a demo/development application and intentionally contains
-  circular dependency examples used for graph inspection.
-- `demo/tmp/graph/` is generated runtime output of the demo's `local` target; it
-  is gitignored and nothing downstream reads it.
-- `OutputAdapter` is a useful internal seam even though custom extension is not
-  currently public; the debt is the absence of a public registration path, not
-  the existence of the interface.
-- `site/public/nodepod-demo/` is build output, written by
-  `demo/scripts/build-nodepod-payload.ts` and gitignored. Bundling it from the
-  `nest build` output rather than from `demo/src/**` is a requirement, not an
-  oversight: Nest resolves constructor dependencies from decorator metadata,
-  which only `tsc` emits.
-- `site/app/utils/nodepod-demo-endpoint.ts` addressing the demo's virtual
-  servers under a route segment the site does not serve, instead of through a
-  service worker, is forced by scope: nodepod registers its worker with
-  `scope: "/"`, and GitHub Pages serves the site from a subpath and cannot
-  answer with `Service-Worker-Allowed`.
+- `demo/src/` intentionally contains circular-dependency examples; a graph tool needs something worth graphing.
+- `demo/tmp/graph/` is gitignored runtime output that nothing downstream reads.
+- `site/public/nodepod-demo/` is build output. Bundling it from the `nest build` output rather than `demo/src/**` is required, not an oversight — Nest resolves constructor dependencies from decorator metadata, which only `tsc` emits.
+- `site/app/utils/nodepod-demo-endpoint.ts` addressing virtual servers under an unserved route segment is forced by the service-worker scope rule, not chosen.
+- **Wildcard CORS and the `0.0.0.0` bind.** Both still true, both documented deliberate: a viewer hosted on a fixed origin cannot be same-origin with an arbitrary developer machine. The token, not the origin check, is the control. (TD-15 is filed separately precisely because it bypasses that control.)
+- **Direct Run returning the raw provider return value.** The endpoint exists to return whatever the invoked method returned; a response DTO would delete the feature rather than shape it. The `DirectRunResult` envelope is the stable part.
+- **Output failures logged rather than thrown.** An inspector that cannot bind its port must not stop a host application from starting.
+- **The `/direct-run/histories` versus `/direct-run/history/...` split.** A genuine naming wart, but these paths are a parsed cross-package contract asserted literally in `site/app/utils/inspector-endpoint-url.test.ts`; renaming breaks the viewer for a cosmetic gain.
+- **No `/v1` URL segment.** The API is versioned in the payload, against the viewer's `MINIMUM_SUPPORTED_GRAPH_OUTPUT_VERSION`, which is the stronger mechanism for a client talking to an independently-versioned developer machine.
+- **The rate limiter keying on socket address.** An attacker with many source addresses evades it, but the real boundary is a 256-bit HMAC signature that is not brute-forceable; the limiter bounds noise, as its own doc comment says.

--- a/docs/technical-debt-report.md
+++ b/docs/technical-debt-report.md
@@ -1,7 +1,10 @@
 # Technical Debt Report
 
 **Scope:** `lib/**` (the published npm package). `demo/**` and `site/**` were not
-audited in this pass except where a `lib/` contract reaches them.
+audited in this pass except where a `lib/` contract reaches them. Three inherited
+documentation findings that live outside `lib/` — TD-11, TD-12, TD-14 — were
+re-checked for accuracy and are retained below, but their surfaces were not
+audited afresh.
 **Last revalidated:** 2026-08-31.
 **Method:** Every finding below was read at the cited file and line. Findings
 inherited from the previous edition of this report were re-checked against
@@ -33,7 +36,7 @@ obsolete.
 | TD-06 | Adding an output type requires four coordinated edits | **Unchanged** | Still four files. Documented as an extension-point cost in `architecture.md`. |
 | TD-07 | Direct Run crosses the config boundary via casts | **Narrowed** → TD-07 below | The body-parsing casts improved; one intersection cast remains. |
 | TD-08 | Schema version duplicated as literal and constant | **Relocated and worse** → TD-08 below | The duplication the report named is fixed; a more dangerous one replaced it. |
-| TD-09 | CORS and path normalization duplicated across adapters | **Partly resolved** → TD-09 below | The `normalizePath` triplication was refuted as a real defect; the CORS duplication stands. |
+| TD-09 | CORS and path normalization duplicated across adapters | **Partly resolved** → TD-09 below | The CORS half is resolved — the second implementation went with the deleted proxy adapter. The `normalizePath` triplication was refuted as duplication, but a two-adapter coupling remains. |
 | TD-10 | Provider and module cycles use incompatible path shapes | **Unchanged** | Still asymmetric; acknowledged in `architecture.md`. |
 | TD-11 | User-facing documentation is stale | **Partly resolved** → TD-11 below | The README no longer calls Direct Run "coming soon"; `site/content/2.configuration/4.access-token.md` now exists. Two claims in `outputs.md` remain wrong. |
 | TD-12 | Documentation ownership overlaps three directories | **Weakened** | `demo/docs/` is now three files (`index.html`, `diagram.html`, `logo.png`) and no longer a competing Markdown surface. Downgraded to Low. |
@@ -230,8 +233,10 @@ so the compiler cannot relate the two either.
 
 **Impact.** Following the bump procedure that `architecture.md` documents —
 raise `GRAPH_OUTPUT_SCHEMA_VERSION` — changes the JSON Schema but leaves the
-emitted graph announcing `"3"` and `$id` pointing at `v3`. **Every test still
-passes**, because the specs assert the same literal the emitter still produces.
+emitted graph announcing `"3"` and `$id` pointing at `v3`. **The library's own Jest
+specs still pass**, because they assert the same literal the emitter still
+produces — and nothing else gates it either: the demo's e2e suites do not assert
+the schema version, and CI does not run them.
 The viewer receives a v4 graph claiming to be v3 and renders it. The documented
 upgrade path silently does not work, and the version gate that exists to make a
 half-done bump visible is what fails first.
@@ -305,9 +310,11 @@ A grep for `Logger` across that file returns nothing: the 508-line router that
 owns every 404 and 500 in the library has no logging at all.
 
 **Impact.** Both halves are inverted — the internal detail goes to the caller
-and nothing goes to the operator. The 500 also answers `text/plain` where every
-other route answers the JSON `{ ok: false, error }` envelope, so no client can
-parse inspector errors generically.
+and nothing goes to the operator. The 500 answers `text/plain`, as does the 404 at
+`http-serve.adapter.ts:198`, while every response dispatched through
+`sendResult` — including the token guard's 401 and the limiter's 429 — answers
+the JSON `{ ok: false, error }` envelope. No client can parse inspector errors
+generically.
 
 ### TD-25 — ts-morph parsing blocks the host's event loop inside a request handler
 


### PR DESCRIPTION
## What this is

A re-validation of `docs/technical-debt-report.md` against current code, plus the
adoption of the **ECC coding standards** as this project's documented baseline.

**No source code is changed.** Two documentation files only.

## Why the debt report needed rewriting

It had drifted badly. Four of its thirteen findings are fully resolved, and its
only `Critical` is obsolete:

| Previously | Now |
|---|---|
| "Default viewer exposes **unauthenticated** Direct Run" | Obsolete — the token guard is attached to every route; an anonymous `POST /direct-run` returns 401, asserted in `demo/test/graph-inspector-security.e2e-spec.ts` |
| "Site imports library types from internal source paths" | Resolved |
| "The only e2e test is a stale Nest scaffold" | Resolved |
| "No CI runs library tests, lint, typecheck, or build" | Resolved — `ci.yml` runs `verify` plus a Node 20/22/24 matrix |
| "`NestGraphInspectorSetup` is 1,619 lines" | 1,166 — size claim shrank, cohesion claim survived with evidence |

## Two new Critical findings

**TD-15 — one malformed request line kills the host process, with no token.**
`route()` runs before `authorize` and outside the `try`, and the server handler
is invoked as `void this.handleRequest(...)` with no `.catch()`. A request line
of `GET http://[invalid HTTP/1.1` makes `new URL()` throw into an unhandled
rejection. Reproduced against a replica of this exact path: `ERR_INVALID_URL`,
non-zero exit, Node v24.19.0, no credentials sent. The access token — the
control that `architecture.md` names as what makes the `0.0.0.0` bind and
wildcard CORS safe — never gets to run.

**TD-16 — a discovery failure crashes the host whenever a non-viewer output is
configured.** `getGraphOutput()` is evaluated as an argument, outside the
`try/catch` that backs the documented "a failing output never fails the
application" guarantee. Viewer-only configs are safe; adding one `json`,
`markdown`, or `http` output turns the same failure into a boot crash.

Both are filed as findings, not fixed here — this PR is documentation.

## ECC adopted as the baseline standard

`docs/development-guidelines.md` gains a Coding standards section recording the
decision, with the parts that a **library** cannot adopt as written:

- **Four carve-outs** — ECC's project-structure template, global bootstrap
  registrations, response DTOs for Direct Run, and REST resource naming /
  URL versioning. Scoped to `lib/**`; `demo/src/**` follows ECC as written.
- **Six mechanism substitutions** — where ECC's obligation binds in full but its
  prescribed Nest mechanism is unavailable (no `@Catch()` filter, no
  `@UseGuards`, no `ValidationPipe`), the section names what discharges it
  instead.

A conformance pass over `lib/**` confirmed **51 ECC rules satisfied**. Candidate
deviations went through an adversarial refutation pass; **25 of 62 did not
survive it** and are not in the report.

### One honest limitation

The most dangerous defect found — **TD-08**, where bumping
`GRAPH_OUTPUT_SCHEMA_VERSION` silently does not change the emitted graph while
every test still passes — was raised by the ECC pass and then *correctly
refuted* as an ECC finding: the rubric has no rule requiring a literal type for
a contract field. It is filed on its own evidence, and
`development-guidelines.md` explains why a clean ECC pass is a floor rather than
a verdict.

## Rebase note

Rebased onto `86c8e36` (WebLLM). That deleted `proxy.adapter.ts` and
`ports/proxy.gateway.ts`, so every citation was re-verified against the merged
tree: TD-09 was rewritten (its CORS half is resolved by the deletion; the
`normalizePath` coupling remains), and line numbers in `setup.ts`, `type.ts`,
`module.ts`, and `viewer-output.adapter.ts` were corrected where the merge
shifted them. All 32 line citations in the report were re-checked against the
files as they stand on this branch.

## Verification

```
pnpm run typecheck   EXIT=0
pnpm run test        EXIT=0   (lib: 12 suites, 101 tests, all passing)
pnpm run verify      completed through the final payload build
```

`test:e2e` was not run: this PR changes no adapter, so the security-surface rule
in `CLAUDE.md` does not apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development guidelines with repository coding standards, documented exceptions, framework adaptations, uncovered areas, and the verification command.
  * Replaced outdated open questions with practical coding guidance.
  * Rewrote the technical debt report with updated scope, methodology, statuses, and revalidated findings.
  * Added newly identified critical, high, medium, and low priority issues while documenting resolved and excluded items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->