### PR TITLE
fix(ops): make Publish Test Package actually publish, without the npmrc warning

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -17,6 +17,14 @@ jobs:
     concurrency:
       group: npm-publish-${{ github.event.release.tag_name }}
       cancel-in-progress: false
+    # actions/setup-node's registry-url writes an .npmrc holding the literal
+    # ${NODE_AUTH_TOKEN} and points NPM_CONFIG_USERCONFIG at it, so every later
+    # pnpm step reads that file and warns when the variable is undefined. An
+    # empty default satisfies the expansion. The publish step overrides it with
+    # the real secret, so the live token never reaches `pnpm install` and the
+    # dependency lifecycle scripts it runs.
+    env:
+      NODE_AUTH_TOKEN: ''
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/publish-test-package.yml
+++ b/.github/workflows/publish-test-package.yml
@@ -18,6 +18,11 @@ concurrency:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # lib/package.json sets publishConfig.provenance, so every publish
+      # attests — flag or no flag — and npm fails outright without this.
+      id-token: write
     # actions/setup-node's registry-url writes an .npmrc holding the literal
     # ${NODE_AUTH_TOKEN} and points NPM_CONFIG_USERCONFIG at it, so every later
     # pnpm step reads that file and warns when the variable is undefined. An

--- a/.github/workflows/publish-test-package.yml
+++ b/.github/workflows/publish-test-package.yml
@@ -18,6 +18,14 @@ concurrency:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    # actions/setup-node's registry-url writes an .npmrc holding the literal
+    # ${NODE_AUTH_TOKEN} and points NPM_CONFIG_USERCONFIG at it, so every later
+    # pnpm step reads that file and warns when the variable is undefined. An
+    # empty default satisfies the expansion. The publish step overrides it with
+    # the real secret, so the live token never reaches `pnpm install` and the
+    # dependency lifecycle scripts it runs.
+    env:
+      NODE_AUTH_TOKEN: ''
     steps:
       - uses: actions/checkout@v7
         with:


### PR DESCRIPTION
Two independent defects in `.github/workflows/publish-test-package.yml`. The reported one was the warning; chasing it surfaced that the workflow **has never successfully published** — the last two dispatches on `main` both failed.

## 1. The npmrc warning

```
WARN  Issue while reading "/home/runner/work/_temp/.npmrc". Failed to replace env in config: ${NODE_AUTH_TOKEN}
```

`actions/setup-node` with `registry-url` writes `/home/runner/work/_temp/.npmrc` containing the *literal* string `${NODE_AUTH_TOKEN}` and exports `NPM_CONFIG_USERCONFIG` pointing at it. Every subsequent `pnpm` invocation reads that file and expands `${…}` from the environment. `NODE_AUTH_TOKEN` was defined only on the publish step, so `setup-node` itself, `pnpm install --frozen-lockfile`, and the build step each had nothing to expand — three warnings per run.

**Fix:** an empty `NODE_AUTH_TOKEN` default on the job. The expansion then succeeds everywhere, and the publish step's own `env` still overrides it with `secrets.NPM_TOKEN`.

Deliberately *not* putting the secret at job level. That would also silence the warning, but it would hand a live publish credential to `pnpm install` and every dependency lifecycle script it runs. Keeping the real token scoped to the one step that publishes is the point of the change, not an incidental detail.

`deploy-site.yml`'s `publish` job has the identical shape and emitted the identical warning, so it gets the same default.

## 2. Provenance had no OIDC token — the publish always failed

```
npm error code EUSAGE
npm error Provenance generation in GitHub Actions requires "write" access to the "id-token" permission
```

`npm publish --tag test` passes no `--provenance` flag, but `lib/package.json` sets `publishConfig.provenance`, so npm attests on **every** publish regardless of the flag. The job inherited only the workflow-level `contents: read`, so the OIDC token provenance is minted from was never available and npm bailed out before uploading.

**Fix:** declare `id-token: write` on the job, the way `deploy-site.yml`'s publish job already does.

Because provenance comes from `publishConfig`, the `--provenance` flag in `deploy-site.yml` is redundant; it is left in place as intent stated at the call site.

## Verification

Root cause reproduced locally against pnpm 10.33 with a byte-for-byte copy of the `.npmrc` `setup-node` writes: unset → the warning; `NODE_AUTH_TOKEN=''` → no warning, and a cold-store `pnpm add` still resolved and downloaded from `registry.npmjs.org`, confirming an empty `_authToken` does not break unauthenticated registry reads.

Then confirmed on real infrastructure by dispatching **Publish Test Package** from this branch:

| Run | Result |
|---|---|
| [34077887050](https://github.com/albasyir/nest-graph-inspector/actions/runs/34077887050) (`main`, before) | ❌ 3 npmrc warnings, failed `EUSAGE` on provenance |
| [34079309963](https://github.com/albasyir/nest-graph-inspector/actions/runs/34079309963) (fix 1 only) | ❌ **0 warnings**, still failed `EUSAGE` |
| [34079405322](https://github.com/albasyir/nest-graph-inspector/actions/runs/34079405322) (both fixes) | ✅ **0 warnings**, published with signed provenance |

Published `nest-graph-inspector@0.8.1-test.1`; `test` dist-tag moved, `latest` untouched at `0.8.0`. No version was burned by the failed attempts — they die before upload.

No source, contract, or documented behaviour changes; `docs/architecture.md`'s workflow table stays accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)